### PR TITLE
Set null as default value for ends_in and ends_on

### DIFF
--- a/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/ServiceItem.php
+++ b/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/ServiceItem.php
@@ -134,8 +134,8 @@ class ServiceItem extends Item
         $quantity = self::getDataValue($data, 'quantity', 1);
         $downloadable = self::getDataValue($data, 'downloadable', false);
         $totalWithTax = self::getDataValue($data, 'total_with_tax', 0);
-        $endsOn = self::getDataValue($data, 'ends_on');
-        $endsIn = self::getDataValue($data, 'ends_in');
+        $endsOn = self::getDataValue($data, 'ends_on', null);
+        $endsIn = self::getDataValue($data, 'ends_in', null);
         $supplier = self::getDataValue($data, 'supplier');
         $rendered = self::getDataValue($data, 'rendered');
 

--- a/src/Infrastructure/Data/DataTransferObject.php
+++ b/src/Infrastructure/Data/DataTransferObject.php
@@ -73,11 +73,11 @@ abstract class DataTransferObject
      *
      * @param array $rawData Raw DTO data.
      * @param string $key Data key.
-     * @param string $default Default value.
+     * @param mixed $default Default value.
      *
      * @return mixed
      */
-    protected static function getDataValue(array $rawData, $key, $default = '')
+    protected static function getDataValue(array $rawData, string $key, mixed $default = '')
     {
         return isset($rawData[$key]) ? $rawData[$key] : $default;
     }


### PR DESCRIPTION
 ### What is the goal?

Avoid "Unhandled error occurred: Invalid request body."  error returned by /orders API when making the PUT request to update the order state.

The root cause is that ends_in and ends_on attributes are mutually exclusive and must be either null or a non-empty string.

 ### References
* **Issue:** [LIS-42](https://sequra.atlassian.net/browse/LIS-42)
 
 ### How is it being implemented?

Changed the fromArray function in the serviceItem data object to set null as default value instead of the default default value '' (empty string)

 ### Opportunistic refactorings

Changed the  getDataValue method signature to reflect the real usage

[LIS-42]: https://sequra.atlassian.net/browse/LIS-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ