### PR TITLE
Make cart items implementation extensible in core

### DIFF
--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -49,6 +49,8 @@ use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreServiceInterface as 
 use SeQura\Core\BusinessLogic\Domain\Integration\Version\VersionServiceInterface as VersionStoreService;
 use SeQura\Core\BusinessLogic\Domain\Merchant\ProxyContracts\MerchantProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\AbstractItemFactory;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\ItemFactory;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\SeQuraOrder;
 use SeQura\Core\BusinessLogic\Domain\Order\ProxyContracts\OrderProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\Order\RepositoryContracts\SeQuraOrderRepositoryInterface;
@@ -423,6 +425,13 @@ class BootstrapComponent extends BaseBootstrapComponent
                     ServiceRegister::getService(OrderService::class),
                     ServiceRegister::getService(ShopOrderService::class)
                 );
+            }
+        );
+
+        ServiceRegister::registerService(
+            AbstractItemFactory::class,
+            static function () {
+                return new ItemFactory();
             }
         );
     }

--- a/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/AbstractItemFactory.php
+++ b/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/AbstractItemFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item;
+
+use InvalidArgumentException;
+
+/**
+ * AbstractItemFactory
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item
+ */
+abstract class AbstractItemFactory
+{
+    /**
+     * Create Item object from array.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @throws InvalidArgumentException
+     */
+    abstract public function createFromArray(array $data): Item;
+
+    /**
+     * Create a list of Item objects from an array of data.
+     *
+     * @param array<array<string, mixed>> $data Array of arrays containing the data of the items.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return Item[]
+     */
+    public function createListFromArray(array $data): array
+    {
+        $items = [];
+        foreach ($data as $itemData) {
+            $item = $this->createFromArray($itemData);
+            if ($item !== null) {
+                $items[] = $item;
+            }
+        }
+        return $items;
+    }
+}

--- a/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/ItemFactory.php
+++ b/src/BusinessLogic/Domain/Order/Models/OrderRequest/Item/ItemFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item;
+
+use InvalidArgumentException;
+
+/**
+ * AbstractItemFactory implementation
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item
+ */
+class ItemFactory extends AbstractItemFactory
+{
+    /**
+     * Create Item object from array.
+     *
+     * @param array<string, mixed> $itemData
+     *
+     * @throws InvalidArgumentException
+     */
+    public function createFromArray(array $itemData): Item
+    {
+        $type = $itemData['type'] ?? null;
+        switch ($type) {
+            case ItemType::TYPE_PRODUCT:
+                return ProductItem::fromArray($itemData);
+            case ItemType::TYPE_HANDLING:
+                return HandlingItem::fromArray($itemData);
+            case ItemType::TYPE_DISCOUNT:
+                return DiscountItem::fromArray($itemData);
+            case ItemType::TYPE_SERVICE:
+                return ServiceItem::fromArray($itemData);
+            case ItemType::TYPE_INVOICE_FEE:
+                return InvoiceFeeItem::fromArray($itemData);
+            case ItemType::TYPE_OTHER_PAYMENT:
+                return OtherPaymentItem::fromArray($itemData);
+            default:
+                throw new InvalidArgumentException('Invalid cart item type ' . $type);
+        }
+    }
+}

--- a/src/Infrastructure/Data/DataTransferObject.php
+++ b/src/Infrastructure/Data/DataTransferObject.php
@@ -77,7 +77,7 @@ abstract class DataTransferObject
      *
      * @return mixed
      */
-    protected static function getDataValue(array $rawData, string $key, mixed $default = '')
+    protected static function getDataValue(array $rawData, string $key, $default = '')
     {
         return isset($rawData[$key]) ? $rawData[$key] : $default;
     }

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -46,6 +46,8 @@ use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Integration\Version\VersionServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Merchant\ProxyContracts\MerchantProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\AbstractItemFactory;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\ItemFactory;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\SeQuraOrder;
 use SeQura\Core\BusinessLogic\Domain\Order\ProxyContracts\OrderProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\Order\RepositoryContracts\SeQuraOrderRepositoryInterface;
@@ -351,6 +353,9 @@ class BaseTestCase extends TestCase
                 return new PromotionalWidgetsController(
                     TestServiceRegister::getService(WidgetSettingsService::class)
                 );
+            },
+            AbstractItemFactory::class => function () {
+                return new ItemFactory();
             }
         ]);
 


### PR DESCRIPTION
 ### What is the goal?

Some integrations that use integration-core, require Cart items from a different type than the ones currently defined, such the RegistrationItem that is needed to represent the registration amount to be paid by the shopper when a service is purchased. Currently, the integration core doesn’t provide a way to extend the available item types with new definitions from the integration side.

 ### References
* **Issue:** [PAR-426](https://sequra.atlassian.net/browse/PAR-426)

 ### How is it being implemented?

Implement the Factory Method pattern to provide a mechanism to create instances of the Item class that can be easily extended by projects using the integration core. The code was extracted from Cart class.

 ### Opportunistic refactorings

Fixed a bug in SeQura\Core\Infrastructure\Data\DataTransferObject::getDataValue() method that makes Unit Tests fail.

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment