### PR TITLE
Fix the issue when cart that is confirmed does not match the current cart

### DIFF
--- a/src/BusinessLogic/Webhook/Handler/WebhookHandler.php
+++ b/src/BusinessLogic/Webhook/Handler/WebhookHandler.php
@@ -123,7 +123,9 @@ class WebhookHandler
      */
     protected function getCreateOrderRequest(string $orderReference): CreateOrderRequest
     {
-        /** @var ShopOrderService $service */
+        /**
+         * @var ShopOrderService $service
+         */
         $service = ServiceRegister::getService(ShopOrderService::class);
 
         return $service->getCreateOrderRequest($orderReference);

--- a/src/BusinessLogic/Webhook/Services/ShopOrderService.php
+++ b/src/BusinessLogic/Webhook/Services/ShopOrderService.php
@@ -2,6 +2,7 @@
 
 namespace SeQura\Core\BusinessLogic\Webhook\Services;
 
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\CreateOrderRequest;
 use SeQura\Core\BusinessLogic\Domain\Webhook\Models\Webhook;
 
 /**
@@ -49,4 +50,13 @@ interface ShopOrderService
      * @return string
      */
     public function getOrderUrl(string $merchantReference): string;
+
+    /**
+     * Retrieves create order request from shop.
+     *
+     * @param string $orderReference
+     *
+     * @return CreateOrderRequest
+     */
+    public function getCreateOrderRequest(string $orderReference): CreateOrderRequest;
 }

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
@@ -2,7 +2,6 @@
 
 namespace SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents;
 
-use SeQura\Core\BusinessLogic\Domain\Order\Builders\CreateOrderRequestBuilder;
 use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidCartItemsException;
 use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidGuiLayoutValueException;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
@@ -18,7 +17,6 @@ use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Platform;
 use SeQura\Core\BusinessLogic\Domain\Webhook\Models\Webhook;
 use SeQura\Core\BusinessLogic\Webhook\Services\ShopOrderService;
 use SeQura\Core\Infrastructure\Http\Exceptions\HttpRequestException;
-use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
 
 class MockShopErrorOrderService implements ShopOrderService
 {
@@ -31,11 +29,10 @@ class MockShopErrorOrderService implements ShopOrderService
      */
     public function updateStatus(
         Webhook $webhook,
-        string  $status,
-        ?int    $reasonCode = null,
+        string $status,
+        ?int $reasonCode = null,
         ?string $message = null
-    )
-    {
+    ) {
         throw new HttpRequestException('Error updating shop order status.');
     }
 

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
@@ -31,10 +31,11 @@ class MockShopErrorOrderService implements ShopOrderService
      */
     public function updateStatus(
         Webhook $webhook,
-        string $status,
-        ?int $reasonCode = null,
+        string  $status,
+        ?int    $reasonCode = null,
         ?string $message = null
-    ) {
+    )
+    {
         throw new HttpRequestException('Error updating shop order status.');
     }
 
@@ -59,7 +60,7 @@ class MockShopErrorOrderService implements ShopOrderService
      */
     public function getOrderUrl(string $merchantReference): string
     {
-        return  '';
+        return '';
     }
 
     /**
@@ -71,7 +72,7 @@ class MockShopErrorOrderService implements ShopOrderService
         $merchant = new Merchant('testMerchantId');
         $merchantReference = new MerchantReference('test123');
         $cart = new Cart('testCurrency', false, [
-            new ProductItem('testItemReference','testName', 5,2, 10, false)
+            new ProductItem('testItemReference', 'testName', 5, 2, 10, false)
         ], $orderReference);
 
         $deliveryMethod = new DeliveryMethod('testDeliveryMethodName');
@@ -93,8 +94,8 @@ class MockShopErrorOrderService implements ShopOrderService
             'ES'
         );
 
-        $customer = new Customer('test@test.test','testCode','testIpNum','testAgent');
-        $platform = new Platform('testName','testVersion','testUName','testDbName','testDbVersion');
+        $customer = new Customer('test@test.test', 'testCode', 'testIpNum', 'testAgent');
+        $platform = new Platform('testName', 'testVersion', 'testUName', 'testDbName', 'testDbVersion');
         $gui = new Gui(Gui::ALLOWED_VALUES['desktop']);
 
         return new CreateOrderRequest(

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopErrorOrderService.php
@@ -2,9 +2,23 @@
 
 namespace SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents;
 
+use SeQura\Core\BusinessLogic\Domain\Order\Builders\CreateOrderRequestBuilder;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidCartItemsException;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidGuiLayoutValueException;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Cart;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\CreateOrderRequest;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Customer;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\DeliveryMethod;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Gui;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\ProductItem;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Merchant;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\MerchantReference;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Platform;
 use SeQura\Core\BusinessLogic\Domain\Webhook\Models\Webhook;
 use SeQura\Core\BusinessLogic\Webhook\Services\ShopOrderService;
 use SeQura\Core\Infrastructure\Http\Exceptions\HttpRequestException;
+use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
 
 class MockShopErrorOrderService implements ShopOrderService
 {
@@ -46,5 +60,54 @@ class MockShopErrorOrderService implements ShopOrderService
     public function getOrderUrl(string $merchantReference): string
     {
         return  '';
+    }
+
+    /**
+     * @throws InvalidCartItemsException
+     * @throws InvalidGuiLayoutValueException
+     */
+    public function getCreateOrderRequest(string $orderReference): CreateOrderRequest
+    {
+        $merchant = new Merchant('testMerchantId');
+        $merchantReference = new MerchantReference('test123');
+        $cart = new Cart('testCurrency', false, [
+            new ProductItem('testItemReference','testName', 5,2, 10, false)
+        ], $orderReference);
+
+        $deliveryMethod = new DeliveryMethod('testDeliveryMethodName');
+        $deliveryAddress = new Address(
+            'testDeliveryAddressCompany',
+            'testDeliveryAddressLine1',
+            'testDeliveryAddressLine2',
+            'testDeliveryAddressPostalCode',
+            'testDeliveryAddressCity',
+            'ES'
+        );
+
+        $invoiceAddress = new Address(
+            'testInvoiceAddressCompany',
+            'testInvoiceAddressLine1',
+            'testInvoiceAddressLine2',
+            'testInvoiceAddressPostalCode',
+            'testInvoiceAddressCity',
+            'ES'
+        );
+
+        $customer = new Customer('test@test.test','testCode','testIpNum','testAgent');
+        $platform = new Platform('testName','testVersion','testUName','testDbName','testDbVersion');
+        $gui = new Gui(Gui::ALLOWED_VALUES['desktop']);
+
+        return new CreateOrderRequest(
+            'testState',
+            $merchant,
+            $cart,
+            $deliveryMethod,
+            $customer,
+            $platform,
+            $deliveryAddress,
+            $invoiceAddress,
+            $gui,
+            $merchantReference
+        );
     }
 }

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
@@ -34,10 +34,11 @@ class MockShopOrderService implements ShopOrderService
      */
     public function updateStatus(
         Webhook $webhook,
-        string $status,
-        ?int $reasonCode = null,
+        string  $status,
+        ?int    $reasonCode = null,
         ?string $message = null
-    ): void {
+    ): void
+    {
     }
 
     /**
@@ -73,7 +74,7 @@ class MockShopOrderService implements ShopOrderService
         $merchant = new Merchant('testMerchantId');
         $merchantReference = new MerchantReference('test123');
         $cart = new Cart('testCurrency', false, [
-            new ProductItem('testItemReference','testName', 5,2, 10, false)
+            new ProductItem('testItemReference', 'testName', 5, 2, 10, false)
         ], $orderReference);
 
         $deliveryMethod = new DeliveryMethod('testDeliveryMethodName');
@@ -95,8 +96,8 @@ class MockShopOrderService implements ShopOrderService
             'ES'
         );
 
-        $customer = new Customer('test@test.test','testCode','testIpNum','testAgent');
-        $platform = new Platform('testName','testVersion','testUName','testDbName','testDbVersion');
+        $customer = new Customer('test@test.test', 'testCode', 'testIpNum', 'testAgent');
+        $platform = new Platform('testName', 'testVersion', 'testUName', 'testDbName', 'testDbVersion');
         $gui = new Gui(Gui::ALLOWED_VALUES['desktop']);
 
         return new CreateOrderRequest(

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
@@ -2,7 +2,6 @@
 
 namespace SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents;
 
-use SeQura\Core\BusinessLogic\Domain\Order\Builders\CreateOrderRequestBuilder;
 use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidCartItemsException;
 use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidGuiLayoutValueException;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
@@ -17,7 +16,6 @@ use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\MerchantReference
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Platform;
 use SeQura\Core\BusinessLogic\Domain\Webhook\Models\Webhook;
 use SeQura\Core\BusinessLogic\Webhook\Services\ShopOrderService;
-use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
 
 /**
  * Class MockShopOrderService
@@ -34,11 +32,10 @@ class MockShopOrderService implements ShopOrderService
      */
     public function updateStatus(
         Webhook $webhook,
-        string  $status,
-        ?int    $reasonCode = null,
+        string $status,
+        ?int $reasonCode = null,
         ?string $message = null
-    ): void
-    {
+    ): void {
     }
 
     /**

--- a/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
+++ b/tests/BusinessLogic/WebhookAPI/MockComponents/MockShopOrderService.php
@@ -2,8 +2,22 @@
 
 namespace SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents;
 
+use SeQura\Core\BusinessLogic\Domain\Order\Builders\CreateOrderRequestBuilder;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidCartItemsException;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidGuiLayoutValueException;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Cart;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\CreateOrderRequest;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Customer;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\DeliveryMethod;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Gui;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Item\ProductItem;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Merchant;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\MerchantReference;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Platform;
 use SeQura\Core\BusinessLogic\Domain\Webhook\Models\Webhook;
 use SeQura\Core\BusinessLogic\Webhook\Services\ShopOrderService;
+use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
 
 /**
  * Class MockShopOrderService
@@ -48,5 +62,54 @@ class MockShopOrderService implements ShopOrderService
     public function getOrderUrl(string $merchantReference): string
     {
         return 'https.test.url/' . $merchantReference;
+    }
+
+    /**
+     * @throws InvalidCartItemsException
+     * @throws InvalidGuiLayoutValueException
+     */
+    public function getCreateOrderRequest(string $orderReference): CreateOrderRequest
+    {
+        $merchant = new Merchant('testMerchantId');
+        $merchantReference = new MerchantReference('test123');
+        $cart = new Cart('testCurrency', false, [
+            new ProductItem('testItemReference','testName', 5,2, 10, false)
+        ], $orderReference);
+
+        $deliveryMethod = new DeliveryMethod('testDeliveryMethodName');
+        $deliveryAddress = new Address(
+            'testDeliveryAddressCompany',
+            'testDeliveryAddressLine1',
+            'testDeliveryAddressLine2',
+            'testDeliveryAddressPostalCode',
+            'testDeliveryAddressCity',
+            'ES'
+        );
+
+        $invoiceAddress = new Address(
+            'testInvoiceAddressCompany',
+            'testInvoiceAddressLine1',
+            'testInvoiceAddressLine2',
+            'testInvoiceAddressPostalCode',
+            'testInvoiceAddressCity',
+            'ES'
+        );
+
+        $customer = new Customer('test@test.test','testCode','testIpNum','testAgent');
+        $platform = new Platform('testName','testVersion','testUName','testDbName','testDbVersion');
+        $gui = new Gui(Gui::ALLOWED_VALUES['desktop']);
+
+        return new CreateOrderRequest(
+            'testState',
+            $merchant,
+            $cart,
+            $deliveryMethod,
+            $customer,
+            $platform,
+            $deliveryAddress,
+            $invoiceAddress,
+            $gui,
+            $merchantReference
+        );
     }
 }

--- a/tests/BusinessLogic/WebhookAPI/WebhookAPITest.php
+++ b/tests/BusinessLogic/WebhookAPI/WebhookAPITest.php
@@ -67,6 +67,7 @@ class WebhookAPITest extends BaseTestCase
     public function testValidWebhook()
     {
         $this->httpClient->setMockResponses([
+            new HttpResponse(200, [], ''),
             new HttpResponse(200, [], '')
         ]);
 


### PR DESCRIPTION
 ### What is the goal?

Fix the issue: Cart that is confirmed does not match the current cart.

 ### How is it being implemented?

Send the order update request to SeQura API without order_ref_1 before creating the order in the shop in order to validate it.

### Does it affect (changes or update) any sensitive data?

No.

 ### How is it tested?

Manual test.

 ### How is it going to be deployed?

Standard deployment.