### PR TITLE
Update credentials validation logic

### DIFF
--- a/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
+++ b/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
@@ -17,7 +17,7 @@ class ValidateConnectionHttpRequest extends HttpRequest
     public function __construct(ValidateConnectionRequest $request)
     {
         parent::__construct(
-            '/merchants/' . $request->getConnectionData()->getMerchantId() . '/payment_methods',
+            '/merchants/credentials',
             [],
             [],
             $this->generateAuthHeaderForValidation($request->getConnectionData()->getAuthorizationCredentials())

--- a/tests/BusinessLogic/Common/ApiResponses/Connection/InvalidCredentialsResponse.json
+++ b/tests/BusinessLogic/Common/ApiResponses/Connection/InvalidCredentialsResponse.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "Access denied"
+  ]
+}


### PR DESCRIPTION
 ### What is the goal?

- Update credentials validation logic by switching to the new [dedicated endpoint for connection validation](https://sequra.readme.io/reference/get_merchants-credentials) on the SeQura API instead of the `merchant/{merchantId}/payment_methods` endpoint that was used until now.

 ### How is it being implemented?

- Update the `SeQura\Core\BusinessLogic\Domain\Connection\Models\ValidateConnectionRequest` with the new request parameters
- Update unit tests to reflect those changes

 ### How is it tested?

- Unit tests
- Integration tests