### PR TITLE
Fix validation of merchant ref

### DIFF
--- a/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
+++ b/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
@@ -16,8 +16,9 @@ class ValidateConnectionHttpRequest extends HttpRequest
 {
     public function __construct(ValidateConnectionRequest $request)
     {
+        $merchantId = $request->getConnectionData()->getMerchantId();
         parent::__construct(
-            '/merchants/credentials',
+            $merchantId ? "/merchants/$merchantId/credentials" : '/merchants/credentials',
             [],
             [],
             $this->generateAuthHeaderForValidation($request->getConnectionData()->getAuthorizationCredentials())

--- a/tests/BusinessLogic/SeQuraAPI/Connection/ConnectionProxyTest.php
+++ b/tests/BusinessLogic/SeQuraAPI/Connection/ConnectionProxyTest.php
@@ -60,7 +60,7 @@ class ConnectionProxyTest extends BaseTestCase
      * @throws InvalidEnvironmentException
      * @throws HttpRequestException
      */
-    public function testConnectionRequestUrl(): void
+    public function testConnectionRequestUrlWithMerchantRef(): void
     {
         $this->httpClient->setMockResponses([
             new HttpResponse(204, [], file_get_contents(
@@ -71,6 +71,33 @@ class ConnectionProxyTest extends BaseTestCase
         $connectionData = new ConnectionData(
             BaseProxy::TEST_MODE,
             'test',
+            new AuthorizationCredentials('test_username', 'test_password')
+        );
+
+        $this->proxy->validateConnection(new ValidateConnectionRequest($connectionData));
+        self::assertCount(1, $this->httpClient->getHistory());
+        $lastRequest = $this->httpClient->getLastRequest();
+        self::assertStringContainsString('merchants/test/credentials', $lastRequest['url']);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws HttpRequestException
+     * @throws InvalidEnvironmentException
+     * @throws HttpRequestException
+     */
+    public function testConnectionRequestUrlWithoutMerchantRef(): void
+    {
+        $this->httpClient->setMockResponses([
+            new HttpResponse(204, [], file_get_contents(
+                __DIR__ . '/../../Common/ApiResponses/Connection/SuccessfulResponse.json'
+            ))
+        ]);
+
+        $connectionData = new ConnectionData(
+            BaseProxy::TEST_MODE,
+            null,
             new AuthorizationCredentials('test_username', 'test_password')
         );
 


### PR DESCRIPTION
 ### What is the goal?

Fixed an issue where the merchant reference, when passed as a connection data property, was not being utilised to construct the API request for credential validation.

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment