### PR TITLE
Send merchant ID in HTTP header

### DIFF
--- a/src/BusinessLogic/Domain/Order/Models/GetAvailablePaymentMethodsRequest.php
+++ b/src/BusinessLogic/Domain/Order/Models/GetAvailablePaymentMethodsRequest.php
@@ -17,11 +17,18 @@ class GetAvailablePaymentMethodsRequest extends DataTransferObject
     protected $orderId;
 
     /**
-     * @param string $orderId
+     * @var string
      */
-    public function __construct(string $orderId)
+    protected $merchantId;
+
+    /**
+     * @param string $orderId
+     * @param string $merchantId
+     */
+    public function __construct(string $orderId, string $merchantId)
     {
         $this->orderId = $orderId;
+        $this->merchantId = $merchantId;
     }
 
     /**
@@ -41,6 +48,24 @@ class GetAvailablePaymentMethodsRequest extends DataTransferObject
     }
 
     /**
+     * @return string
+     */
+    public function getMerchantId(): string
+    {
+        return $this->merchantId;
+    }
+
+    /**
+     * @param string $merchantId
+     *
+     * @return void
+     */
+    public function setMerchantId(string $merchantId): void
+    {
+        $this->merchantId = $merchantId;
+    }
+
+    /**
      * Create a GetAvailablePaymentMethodsRequest instance from an array.
      *
      * @param mixed[] $data
@@ -50,7 +75,8 @@ class GetAvailablePaymentMethodsRequest extends DataTransferObject
     public static function fromArray(array $data): self
     {
         return new self(
-            self::getDataValue($data, 'order_id')
+            self::getDataValue($data, 'order_id'),
+            self::getDataValue($data, 'merchant_id')
         );
     }
 
@@ -60,6 +86,7 @@ class GetAvailablePaymentMethodsRequest extends DataTransferObject
     public function toArray(): array
     {
         $data['order_id'] = $this->orderId;
+        $data['merchant_id'] = $this->merchantId;
 
         return $data;
     }

--- a/src/BusinessLogic/Domain/Order/Models/GetFormRequest.php
+++ b/src/BusinessLogic/Domain/Order/Models/GetFormRequest.php
@@ -32,17 +32,29 @@ class GetFormRequest extends DataTransferObject
     protected $ajax;
 
     /**
+     * @var string
+     */
+    protected $merchantId;
+
+    /**
      * @param string $orderId
      * @param string|null $product
      * @param string|null $campaign
      * @param bool|null $ajax
+     * @param string $merchantId
      */
-    public function __construct(string $orderId, string $product = null, string $campaign = null, bool $ajax = null)
-    {
+    public function __construct(
+        string $orderId,
+        string $product = null,
+        string $campaign = null,
+        bool $ajax = null,
+        string $merchantId = ''
+    ) {
         $this->orderId = $orderId;
         $this->product = $product;
         $this->campaign = $campaign;
         $this->ajax = $ajax;
+        $this->merchantId = $merchantId;
     }
 
     /**
@@ -78,6 +90,14 @@ class GetFormRequest extends DataTransferObject
     }
 
     /**
+     * @return string
+     */
+    public function getMerchantId(): string
+    {
+        return $this->merchantId;
+    }
+
+    /**
      * Create a GetFormRequest instance from an array.
      *
      * @param mixed[] $data
@@ -90,7 +110,8 @@ class GetFormRequest extends DataTransferObject
             self::getDataValue($data, 'order_id'),
             self::getDataValue($data, 'product', null),
             self::getDataValue($data, 'campaign', null),
-            self::getDataValue($data, 'ajax', null)
+            self::getDataValue($data, 'ajax', null),
+            self::getDataValue($data, 'merchantId', '')
         );
     }
 
@@ -103,6 +124,7 @@ class GetFormRequest extends DataTransferObject
         $data['product'] = $this->product;
         $data['campaign'] = $this->campaign;
         $data['ajax'] = $this->ajax;
+        $data['merchantId'] = $this->merchantId;
 
         return $data;
     }

--- a/src/BusinessLogic/Domain/Order/Service/OrderService.php
+++ b/src/BusinessLogic/Domain/Order/Service/OrderService.php
@@ -109,21 +109,29 @@ class OrderService
      */
     public function getAvailablePaymentMethods(SeQuraOrder $order): array
     {
-        return $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest($order->getReference()));
+        return $this->proxy->getAvailablePaymentMethods(
+            new GetAvailablePaymentMethodsRequest(
+                $order->getReference(),
+                $order->getMerchant()->getId()
+            )
+        );
     }
 
     /**
      * Gets available payment methods for solicited order in categories.
      *
      * @param string $orderRef
+     * @param string $merchantId
      *
      * @return SeQuraPaymentMethodCategory[]
      *
      * @throws HttpRequestException
      */
-    public function getAvailablePaymentMethodsInCategories(string $orderRef): array
+    public function getAvailablePaymentMethodsInCategories(string $orderRef, string $merchantId): array
     {
-        return $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest($orderRef));
+        return $this->proxy->getAvailablePaymentMethodsInCategories(
+            new GetAvailablePaymentMethodsRequest($orderRef, $merchantId)
+        );
     }
 
     /**
@@ -151,7 +159,15 @@ class OrderService
             );
         }
 
-        return $this->proxy->getForm(new GetFormRequest($existingOrder->getReference(), $product, $campaign, $ajax));
+        return $this->proxy->getForm(
+            new GetFormRequest(
+                $existingOrder->getReference(),
+                $product,
+                $campaign,
+                $ajax,
+                $existingOrder->getMerchant()->getId()
+            )
+        );
     }
 
     /**

--- a/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
@@ -11,7 +11,7 @@ use SeQura\Core\Infrastructure\Http\HttpClient;
  *
  * @package SeQura\Core\BusinessLogic\SeQuraAPI\Authorization
  */
-class AuthorizedProxy extends BaseProxy
+abstract class AuthorizedProxy extends BaseProxy
 {
     public const AUTHORIZATION_HEADER_KEY = 'Authorization';
     public const AUTHORIZATION_HEADER_VALUE_PREFIX = 'Authorization: Basic ';
@@ -22,6 +22,11 @@ class AuthorizedProxy extends BaseProxy
      * @var ConnectionDataRepositoryInterface
      */
     protected $connectionDataRepository;
+
+    /**
+     * @var string $merchantId
+     */
+    private $merchantId = '';
 
     /**
      * AuthorizedProxy constructor.
@@ -62,8 +67,18 @@ class AuthorizedProxy extends BaseProxy
             parent::getHeaders(),
             [
                 self::AUTHORIZATION_HEADER_KEY => self::AUTHORIZATION_HEADER_VALUE_PREFIX . $token,
-                self::MERCHANT_ID_HEADER_KEY => $connectionData->getMerchantId(),
+                self::MERCHANT_ID_HEADER_KEY => $this->merchantId,
             ]
         );
+    }
+
+    /**
+     * @param string $merchantId
+     *
+     * @return void
+     */
+    public function setMerchantId(string $merchantId): void
+    {
+        $this->merchantId = $merchantId;
     }
 }

--- a/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
@@ -16,6 +16,8 @@ class AuthorizedProxy extends BaseProxy
     public const AUTHORIZATION_HEADER_KEY = 'Authorization';
     public const AUTHORIZATION_HEADER_VALUE_PREFIX = 'Authorization: Basic ';
 
+    public const MERCHANT_ID_HEADER_KEY = 'Sequra-Merchant-Id';
+
     /**
      * @var ConnectionDataRepositoryInterface
      */
@@ -58,7 +60,10 @@ class AuthorizedProxy extends BaseProxy
 
         return array_merge(
             parent::getHeaders(),
-            [self::AUTHORIZATION_HEADER_KEY => self::AUTHORIZATION_HEADER_VALUE_PREFIX . $token]
+            [
+                self::AUTHORIZATION_HEADER_KEY => self::AUTHORIZATION_HEADER_VALUE_PREFIX . $token,
+                self::MERCHANT_ID_HEADER_KEY => $connectionData->getMerchantId(),
+            ]
         );
     }
 }

--- a/src/BusinessLogic/SeQuraAPI/Merchant/MerchantProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/Merchant/MerchantProxy.php
@@ -23,6 +23,7 @@ class MerchantProxy extends AuthorizedProxy implements MerchantProxyInterface
      */
     public function getAvailablePaymentMethods(GetAvailablePaymentMethodsRequest $request): array
     {
+        $this->setMerchantId($request->getMerchantId());
         $response = $this->get(new GetAvailablePaymentMethodsHttpRequest($request))->decodeBodyToArray();
 
         return $this->getListOfPaymentMethods($response);

--- a/src/BusinessLogic/SeQuraAPI/OrderReport/OrderReportProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/OrderReport/OrderReportProxy.php
@@ -19,6 +19,8 @@ class OrderReportProxy extends AuthorizedProxy implements OrderReportProxyInterf
      */
     public function sendReport(SendOrderReportRequest $request): bool
     {
+        $this->setMerchantId($request->getMerchant()->getId());
+
         return $this->post(new SendOrderReportHttpRequest($request))->isSuccessful();
     }
 }

--- a/tests/BusinessLogic/CheckoutAPI/Solicitation/SolicitationGetFormCheckoutApiTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/Solicitation/SolicitationGetFormCheckoutApiTest.php
@@ -68,7 +68,10 @@ class SolicitationGetFormCheckoutApiTest extends BaseTestCase
         // Assert
         self::assertTrue($response->isSuccessful(), json_encode($response->toArray(), JSON_PRETTY_PRINT));
         self::assertEquals($expectedForm, $response->getIdentificationForm());
-        self::assertEquals(new GetFormRequest('testOrderRef', 'pp5', null, false), $this->orderProxy->getLastGetFormRequest());
+        self::assertEquals(
+            new GetFormRequest('testOrderRef', 'pp5', null, false, 'testMerchantId'),
+            $this->orderProxy->getLastGetFormRequest()
+        );
     }
 
     public function testGetOrderFormForMissingSeQuraOrder()

--- a/tests/BusinessLogic/Domain/Order/Services/OrderServiceTest.php
+++ b/tests/BusinessLogic/Domain/Order/Services/OrderServiceTest.php
@@ -154,7 +154,7 @@ class OrderServiceTest extends BaseTestCase
         );
 
         $this->httpClient->setMockResponses([new HttpResponse(200, [], $rawResponseBody)]);
-        $response = $this->orderService->getAvailablePaymentMethodsInCategories('testId');
+        $response = $this->orderService->getAvailablePaymentMethodsInCategories('testId', 'testMerchantId');
         $responseBody = json_decode($rawResponseBody, true);
         $paymentMethodCategories = [];
 

--- a/tests/BusinessLogic/SeQuraAPI/Order/OrderProxyTest.php
+++ b/tests/BusinessLogic/SeQuraAPI/Order/OrderProxyTest.php
@@ -104,7 +104,7 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId', 'testMerchantId'));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -124,7 +124,7 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId', 'testMerchantId'));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -144,7 +144,7 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId', 'testMerchantId'));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -163,7 +163,10 @@ class OrderProxyTest extends BaseTestCase
         );
 
         $this->httpClient->setMockResponses([new HttpResponse(200, [], $rawResponseBody)]);
-        $response = $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('testId'));
+        $response = $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest(
+            'testId',
+            'testMerchantId'
+        ));
         $responseBody = json_decode($rawResponseBody, true);
         $paymentMethods = [];
 
@@ -187,9 +190,18 @@ class OrderProxyTest extends BaseTestCase
             self::assertEquals($paymentMethods[$i]['max_amount'] ?? null, $response[$i]->getMaxAmount());
             self::assertEquals($paymentMethods[$i]['cost_description'], $response[$i]->getCostDescription());
             self::assertEquals($paymentMethods[$i]['cost']['setup_fee'], $response[$i]->getCost()->getSetupFee());
-            self::assertEquals($paymentMethods[$i]['cost']['instalment_fee'], $response[$i]->getCost()->getInstalmentFee());
-            self::assertEquals($paymentMethods[$i]['cost']['down_payment_fees'], $response[$i]->getCost()->getDownPaymentFees());
-            self::assertEquals($paymentMethods[$i]['cost']['instalment_total'], $response[$i]->getCost()->getInstalmentTotal());
+            self::assertEquals(
+                $paymentMethods[$i]['cost']['instalment_fee'],
+                $response[$i]->getCost()->getInstalmentFee()
+            );
+            self::assertEquals(
+                $paymentMethods[$i]['cost']['down_payment_fees'],
+                $response[$i]->getCost()->getDownPaymentFees()
+            );
+            self::assertEquals(
+                $paymentMethods[$i]['cost']['instalment_total'],
+                $response[$i]->getCost()->getInstalmentTotal()
+            );
         }
     }
 
@@ -208,7 +220,7 @@ class OrderProxyTest extends BaseTestCase
         $this->httpClient->setMockResponses([new HttpResponse(403, [], $rawResponseBody)]);
 
         try {
-            $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('test'));
+            $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('test', 'testMerchantId'));
         } catch (HttpApiInvalidUrlParameterException $exception) {
         }
 
@@ -231,7 +243,7 @@ class OrderProxyTest extends BaseTestCase
         $this->httpClient->setMockResponses([new HttpResponse(401, [], $rawResponseBody)]);
 
         try {
-            $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('test'));
+            $this->proxy->getAvailablePaymentMethods(new GetAvailablePaymentMethodsRequest('test', 'testMerchantId'));
         } catch (HttpApiUnauthorizedException $exception) {
         }
 
@@ -255,7 +267,10 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+            'testId',
+            'testMerchantId'
+        ));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -275,7 +290,10 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+            'testId',
+            'testMerchantId'
+        ));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -295,7 +313,10 @@ class OrderProxyTest extends BaseTestCase
             ))
         ]);
 
-        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('testId'));
+        $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+            'testId',
+            'testMerchantId'
+        ));
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
@@ -314,7 +335,10 @@ class OrderProxyTest extends BaseTestCase
         );
 
         $this->httpClient->setMockResponses([new HttpResponse(200, [], $rawResponseBody)]);
-        $response = $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('testId'));
+        $response = $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+            'testId',
+            'testMerchantId'
+        ));
         $responseBody = json_decode($rawResponseBody, true);
         $paymentMethodCategories = [];
 
@@ -328,22 +352,70 @@ class OrderProxyTest extends BaseTestCase
             self::assertEquals($paymentMethodCategories[$i]['icon'], $response[$i]->getIcon());
 
             for ($j = 0, $jMax = count($paymentMethodCategories[$i]['methods']); $j < $jMax; $j++) {
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['product'], $response[$i]->getMethods()[$j]->getProduct());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['campaign'], $response[$i]->getMethods()[$j]->getCampaign());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['title'], $response[$i]->getMethods()[$j]->getTitle());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['long_title'], $response[$i]->getMethods()[$j]->getLongTitle());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['claim'], $response[$i]->getMethods()[$j]->getClaim());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['description'], $response[$i]->getMethods()[$j]->getDescription());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['icon'], $response[$i]->getMethods()[$j]->getIcon());
-                self::assertEquals(new DateTime($paymentMethodCategories[$i]['methods'][$j]['starts_at']), $response[$i]->getMethods()[$j]->getStartsAt());
-                self::assertEquals(new DateTime($paymentMethodCategories[$i]['methods'][$j]['ends_at']), $response[$i]->getMethods()[$j]->getEndsAt());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['min_amount'] ?? null, $response[$i]->getMethods()[$j]->getMinAmount());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['max_amount'] ?? null, $response[$i]->getMethods()[$j]->getMaxAmount());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['cost_description'], $response[$i]->getMethods()[$j]->getCostDescription());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['cost']['setup_fee'], $response[$i]->getMethods()[$j]->getCost()->getSetupFee());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['cost']['instalment_fee'], $response[$i]->getMethods()[$j]->getCost()->getInstalmentFee());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['cost']['down_payment_fees'], $response[$i]->getMethods()[$j]->getCost()->getDownPaymentFees());
-                self::assertEquals($paymentMethodCategories[$i]['methods'][$j]['cost']['instalment_total'], $response[$i]->getMethods()[$j]->getCost()->getInstalmentTotal());
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['product'],
+                    $response[$i]->getMethods()[$j]->getProduct()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['campaign'],
+                    $response[$i]->getMethods()[$j]->getCampaign()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['title'],
+                    $response[$i]->getMethods()[$j]->getTitle()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['long_title'],
+                    $response[$i]->getMethods()[$j]->getLongTitle()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['claim'],
+                    $response[$i]->getMethods()[$j]->getClaim()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['description'],
+                    $response[$i]->getMethods()[$j]->getDescription()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['icon'],
+                    $response[$i]->getMethods()[$j]->getIcon()
+                );
+                self::assertEquals(
+                    new DateTime($paymentMethodCategories[$i]['methods'][$j]['starts_at']),
+                    $response[$i]->getMethods()[$j]->getStartsAt()
+                );
+                self::assertEquals(
+                    new DateTime($paymentMethodCategories[$i]['methods'][$j]['ends_at']),
+                    $response[$i]->getMethods()[$j]->getEndsAt()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['min_amount'] ?? null,
+                    $response[$i]->getMethods()[$j]->getMinAmount()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['max_amount'] ?? null,
+                    $response[$i]->getMethods()[$j]->getMaxAmount()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['cost_description'],
+                    $response[$i]->getMethods()[$j]->getCostDescription()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['cost']['setup_fee'],
+                    $response[$i]->getMethods()[$j]->getCost()->getSetupFee()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['cost']['instalment_fee'],
+                    $response[$i]->getMethods()[$j]->getCost()->getInstalmentFee()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['cost']['down_payment_fees'],
+                    $response[$i]->getMethods()[$j]->getCost()->getDownPaymentFees()
+                );
+                self::assertEquals(
+                    $paymentMethodCategories[$i]['methods'][$j]['cost']['instalment_total'],
+                    $response[$i]->getMethods()[$j]->getCost()->getInstalmentTotal()
+                );
             }
         }
     }
@@ -363,7 +435,10 @@ class OrderProxyTest extends BaseTestCase
         $this->httpClient->setMockResponses([new HttpResponse(403, [], $rawResponseBody)]);
 
         try {
-            $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('test'));
+            $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+                'test',
+                'testMerchantId'
+            ));
         } catch (HttpApiInvalidUrlParameterException $exception) {
         }
 
@@ -386,7 +461,10 @@ class OrderProxyTest extends BaseTestCase
         $this->httpClient->setMockResponses([new HttpResponse(401, [], $rawResponseBody)]);
 
         try {
-            $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest('test'));
+            $this->proxy->getAvailablePaymentMethodsInCategories(new GetAvailablePaymentMethodsRequest(
+                'test',
+                'testMerchantId'
+            ));
         } catch (HttpApiUnauthorizedException $exception) {
         }
 
@@ -639,7 +717,9 @@ class OrderProxyTest extends BaseTestCase
      */
     public function testMinimalCreateOrderSuccessfulResponse(): void
     {
-        $this->httpClient->setMockResponses([new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/orders/testUUID'], '')]);
+        $this->httpClient->setMockResponses([
+            new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/orders/testUUID'], '')
+        ]);
 
         $createOrderRequest = $this->generateMinimalCreateOrderRequest();
         $response = $this->proxy->createOrder($createOrderRequest);
@@ -655,7 +735,9 @@ class OrderProxyTest extends BaseTestCase
      */
     public function testFullCreateOrderSuccessfulResponse(): void
     {
-        $this->httpClient->setMockResponses([new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/orders/testUUID'], '')]);
+        $this->httpClient->setMockResponses([
+            new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/orders/testUUID'], '')
+        ]);
 
         $createOrderRequest = $this->generateFullCreateOrderRequest();
         $response = $this->proxy->createOrder($createOrderRequest);
@@ -733,7 +815,10 @@ class OrderProxyTest extends BaseTestCase
 
         self::assertCount(1, $this->httpClient->getHistory());
         $lastRequest = $this->httpClient->getLastRequest();
-        self::assertStringContainsString('https://sandbox.sequrapi.com/merchants/testMerchantId/orders/testOrderRef1', $lastRequest['url']);
+        self::assertStringContainsString(
+            'https://sandbox.sequrapi.com/merchants/testMerchantId/orders/testOrderRef1',
+            $lastRequest['url']
+        );
     }
 
     /**
@@ -813,7 +898,13 @@ class OrderProxyTest extends BaseTestCase
      */
     public function testMinimalUpdateOrderSuccessfulResponse(): void
     {
-        $this->httpClient->setMockResponses([new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/merchants/test/orders/testOrderRef1'], '')]);
+        $this->httpClient->setMockResponses([
+            new HttpResponse(
+                204,
+                ['location' => 'https://sandbox.sequrapi.com/merchants/test/orders/testOrderRef1'],
+                ''
+            )
+        ]);
 
         $updateOrderRequest = $this->generateMinimalUpdateOrderRequest();
         $response = $this->proxy->updateOrder($updateOrderRequest);
@@ -828,7 +919,13 @@ class OrderProxyTest extends BaseTestCase
      */
     public function testFullUpdateOrderSuccessfulResponse(): void
     {
-        $this->httpClient->setMockResponses([new HttpResponse(204, ['location' => 'https://sandbox.sequrapi.com/merchants/test/orders/testOrderRef1'], '')]);
+        $this->httpClient->setMockResponses([
+            new HttpResponse(
+                204,
+                ['location' => 'https://sandbox.sequrapi.com/merchants/test/orders/testOrderRef1'],
+                ''
+            )
+        ]);
 
         $updateOrderRequest = $this->generateFullUpdateOrderRequest();
         $response = $this->proxy->updateOrder($updateOrderRequest);


### PR DESCRIPTION
### What is the goal?

- Send merchant ID in HTTP headers at requests to SeQura API endpoints

 ### References
* **Issue:** [LIS-71](https://sequra.atlassian.net/browse/LIS-71)

 ### How is it being implemented?

- Added additional HTTP header in Proxy classes

 ### How is it tested?
- Unit tests

[LIS-71]: https://sequra.atlassian.net/browse/LIS-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
