### PR TITLE
refactor/PAR-570 Refactor exceptions message

### DIFF
--- a/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
+++ b/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
@@ -38,7 +38,7 @@ class HttpApiRequestException extends HttpRequestException
         $errors = self::getErrorMessages($response);
 
         $instance = new static(
-            !empty($errors) ? join('. ', $errors) : $customMessage,
+            !empty($errors) ? implode('. ', $errors) : $customMessage,
             $response->getStatus()
         );
 

--- a/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
+++ b/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
@@ -38,7 +38,7 @@ class HttpApiRequestException extends HttpRequestException
         $errors = self::getErrorMessages($response);
 
         $instance = new static(
-            !empty($errors) ? implode('. ', $errors) : $customMessage,
+            !empty($errors) ? implode('. ', $errors) : ($customMessage ?? 'An unknown error occurred.'),
             $response->getStatus()
         );
 

--- a/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
+++ b/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
@@ -58,6 +58,9 @@ class HttpApiRequestException extends HttpRequestException
     {
         $errors = [];
         $responseBody = json_decode($response->getBody(), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return $errors; // Return empty array if JSON decoding fails
+        }
         if (!is_array($responseBody) || !isset($responseBody['errors'])) {
             return $errors;
         }

--- a/tests/BusinessLogic/SeQuraAPI/Merchant/MerchantProxyTest.php
+++ b/tests/BusinessLogic/SeQuraAPI/Merchant/MerchantProxyTest.php
@@ -186,7 +186,7 @@ class MerchantProxyTest extends BaseTestCase
 
         $responseBody = json_decode($rawResponseBody, true);
         self::assertNotNull($exception);
-        self::assertEquals('Access forbidden.', $exception->getMessage());
+        self::assertEquals('Bad merchant id \'test\' for logeecom', $exception->getMessage());
         self::assertEquals(403, $exception->getCode());
         self::assertEquals($responseBody['errors'] ?? [], $exception->getErrors());
     }

--- a/tests/BusinessLogic/SeQuraAPI/Order/OrderProxyTest.php
+++ b/tests/BusinessLogic/SeQuraAPI/Order/OrderProxyTest.php
@@ -226,7 +226,7 @@ class OrderProxyTest extends BaseTestCase
 
         $responseBody = json_decode($rawResponseBody, true);
         self::assertNotNull($exception);
-        self::assertEquals('Access forbidden.', $exception->getMessage());
+        self::assertEquals('Bad order id \'test\' for logeecom', $exception->getMessage());
         self::assertEquals(403, $exception->getCode());
         self::assertEquals($responseBody['errors'] ?? [], $exception->getErrors());
     }
@@ -444,7 +444,7 @@ class OrderProxyTest extends BaseTestCase
 
         $responseBody = json_decode($rawResponseBody, true);
         self::assertNotNull($exception);
-        self::assertEquals('Access forbidden.', $exception->getMessage());
+        self::assertEquals('Bad order id \'test\' for logeecom', $exception->getMessage());
         self::assertEquals(403, $exception->getCode());
         self::assertEquals($responseBody['errors'] ?? [], $exception->getErrors());
     }
@@ -774,7 +774,7 @@ class OrderProxyTest extends BaseTestCase
         $responseBody = json_decode($rawResponseBody, true);
 
         self::assertNotNull($exception);
-        self::assertEquals('Access forbidden.', $exception->getMessage());
+        self::assertEquals('Bad merchant id \'test\' for logeecom', $exception->getMessage());
         self::assertEquals(403, $exception->getCode());
         self::assertEquals($responseBody['errors'] ?? [], $exception->getErrors());
     }
@@ -955,7 +955,7 @@ class OrderProxyTest extends BaseTestCase
         $responseBody = json_decode($rawResponseBody, true);
 
         self::assertNotNull($exception);
-        self::assertEquals('Access forbidden.', $exception->getMessage());
+        self::assertEquals('You do not have access to this URL', $exception->getMessage());
         self::assertEquals(403, $exception->getCode());
         self::assertEquals($responseBody['errors'] ?? [], $exception->getErrors());
     }


### PR DESCRIPTION
 ### What is the goal?

The current implementation of the class `HttpApiRequestException` overwrites the original error message that comes in the API response body with a `customMessage` argument when its value isn’t null (which always happens because the string is hardcoded). [See examples](https://github.com/sequra/integration-core/blob/0073398a8bda3fd77bb12914775b352e04bd6a1d/src/BusinessLogic/SeQuraAPI/BaseProxy.php#L228)

This leads to the loss of the original error, making debugging more difficult.

This PR aims to change the current implementation to use the `customMessage` only when no API error message exists. Also, verify whether the expected payload in the code matches the one that is actually returned

 ### References
* **Issue:** PAR-570

 ### How is it being implemented?

This pull request refactors the error handling logic in the `HttpApiRequestException` class to improve code readability and encapsulation. The most notable change is the introduction of a new private method, `getErrorMessages`, which centralizes the extraction of error messages from the HTTP response body.

#### Refactoring for improved error handling:

* [`src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php`](diffhunk://#diff-4c8a0174f00eb5655ff98cdea7f329771dcbb8b04516b5c1dac97e43d709481bL38-R74): Added a private `getErrorMessages` method to encapsulate logic for extracting error messages from the HTTP response body. This method handles various formats of errors (`string` or `array` with a `title` key) and ensures robust parsing.
* [`src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php`](diffhunk://#diff-4c8a0174f00eb5655ff98cdea7f329771dcbb8b04516b5c1dac97e43d709481bL38-R74): Updated the `fromErrorResponse` method to use the new `getErrorMessages` method, simplifying the error extraction logic and improving maintainability.

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment