### PR TITLE
Enrich widget initializer with additional data

### DIFF
--- a/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
@@ -35,13 +35,16 @@ class PromotionalWidgetsCheckoutResponse extends Response
 
         return [
             'assetKey' => $this->widgetInitializer->getAssetKey(),
-            'merchantId' => $this->widgetInitializer->getMerchantId(),
+            'merchant' => $this->widgetInitializer->getMerchantId(),
             'products' => $this->widgetInitializer->getProducts(),
             'scriptUri' => $this->widgetInitializer->getScriptUri(),
             'locale' => $this->widgetInitializer->getLocale(),
             'currency' => $this->widgetInitializer->getCurrency(),
             'decimalSeparator' => $this->widgetInitializer->getDecimalSeparator(),
             'thousandSeparator' => $this->widgetInitializer->getThousandSeparator(),
+            'isProductListingEnabled' => $this->widgetInitializer->isProductListingEnabled(),
+            'isProductEnabled' => $this->widgetInitializer->isProductPageEnabled(),
+            'widgetConfig' => $this->widgetInitializer->getWidgetConfig() ?? ''
         ];
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
@@ -35,7 +35,7 @@ class PromotionalWidgetsCheckoutResponse extends Response
 
         return [
             'assetKey' => $this->widgetInitializer->getAssetKey(),
-            'merchant' => $this->widgetInitializer->getMerchantId(),
+            'merchantId' => $this->widgetInitializer->getMerchantId(),
             'products' => $this->widgetInitializer->getProducts(),
             'scriptUri' => $this->widgetInitializer->getScriptUri(),
             'locale' => $this->widgetInitializer->getLocale(),

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Models/WidgetInitializer.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Models/WidgetInitializer.php
@@ -41,6 +41,18 @@ class WidgetInitializer
      * @var string
      */
     protected $thousandSeparator;
+    /**
+     * @var bool
+     */
+    protected $isProductListingEnabled;
+    /**
+     * @var bool
+     */
+    protected $isProductPageEnabled;
+    /**
+     * @var string|null
+     */
+    protected $widgetConfig;
 
     /**
      * @param string $assetKey
@@ -51,6 +63,9 @@ class WidgetInitializer
      * @param string $currency
      * @param string $decimalSeparator
      * @param string $thousandSeparator
+     * @param bool $isProductListingEnabled
+     * @param bool $isProductPageEnabled
+     * @param string|null $widgetConfig
      */
     public function __construct(
         string $assetKey,
@@ -60,7 +75,10 @@ class WidgetInitializer
         string $locale = 'es-ES',
         string $currency = 'EUR',
         string $decimalSeparator = ',',
-        string $thousandSeparator = '.'
+        string $thousandSeparator = '.',
+        bool $isProductListingEnabled = false,
+        bool $isProductPageEnabled = false,
+        ?string $widgetConfig = null
     ) {
         $this->assetKey = $assetKey;
         $this->merchantId = $merchantId;
@@ -70,6 +88,9 @@ class WidgetInitializer
         $this->currency = $currency;
         $this->decimalSeparator = $decimalSeparator;
         $this->thousandSeparator = $thousandSeparator;
+        $this->isProductListingEnabled = $isProductListingEnabled;
+        $this->isProductPageEnabled = $isProductPageEnabled;
+        $this->widgetConfig = $widgetConfig;
     }
 
     /**
@@ -134,5 +155,29 @@ class WidgetInitializer
     public function getThousandSeparator(): string
     {
         return $this->thousandSeparator;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProductListingEnabled(): bool
+    {
+        return $this->isProductListingEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProductPageEnabled(): bool
+    {
+        return $this->isProductPageEnabled;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWidgetConfig(): ?string
+    {
+        return $this->widgetConfig;
     }
 }

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
@@ -142,7 +142,10 @@ class WidgetSettingsService
             $this->widgetConfigurator->getLocale() ?? 'es-ES',
             $this->widgetConfigurator->getCurrency() ?? 'EUR',
             $this->widgetConfigurator->getDecimalSeparator() ?? ',',
-            $this->widgetConfigurator->getThousandsSeparator() ?? '.'
+            $this->widgetConfigurator->getThousandsSeparator() ?? '.',
+            $widgetSettings->isShowInstallmentsInProductListing(),
+            $widgetSettings->isDisplayOnProductPage(),
+            $widgetSettings->getWidgetConfig()
         );
     }
 

--- a/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
@@ -141,13 +141,16 @@ class PromotionalWidgetsApiTest extends BaseTestCase
         //Assert
         self::assertEquals([
             'assetKey' => 'assets1',
-            'merchantId' => 'merchant1',
+            'merchant' => 'merchant1',
             'products' => ['product1', 'product2'],
             'scriptUri' => 'testScriptUri.com',
             'locale' => 'es',
             'currency' => 'EUR',
             'decimalSeparator' => ',',
             'thousandSeparator' => '.',
+            'isProductListingEnabled' => false,
+            'isProductEnabled' => false,
+            'widgetConfig' => ''
         ], $response->toArray());
     }
 

--- a/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
@@ -141,7 +141,7 @@ class PromotionalWidgetsApiTest extends BaseTestCase
         //Assert
         self::assertEquals([
             'assetKey' => 'assets1',
-            'merchant' => 'merchant1',
+            'merchantId' => 'merchant1',
             'products' => ['product1', 'product2'],
             'scriptUri' => 'testScriptUri.com',
             'locale' => 'es',


### PR DESCRIPTION
### What is the goal?

- Upgrade Hyva Themes compatibility module to work with latest Magento plugin changes. Move widget initialization logic needed for Hyva themes to CORE.

 ### References
* **Issue:** [LIS-84](https://sequra.atlassian.net/browse/LIS-84)

 ### How is it being implemented?

- Enrich widget initializator response with additional data from Widget entity: isProductListingEnabled, isProductEnabled and widgetConfig

### How is it tested?
- Unit tests

[LIS-85]: https://sequra.atlassian.net/browse/LIS-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIS-85]: https://sequra.atlassian.net/browse/LIS-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIS-84]: https://sequra.atlassian.net/browse/LIS-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ