### PR TITLE
Remove option to enable/disable promotional widgets

### DIFF
--- a/src/BusinessLogic/AdminAPI/Integration/IntegrationController.php
+++ b/src/BusinessLogic/AdminAPI/Integration/IntegrationController.php
@@ -51,15 +51,13 @@ class IntegrationController
     /**
      * Gets the UI state for the integration.
      *
-     * @param bool $useWidgets
-     *
      * @return IntegrationUIStateResponse
      *
      * @throws Exception
      */
-    public function getUIState(bool $useWidgets = true): IntegrationUIStateResponse
+    public function getUIState(): IntegrationUIStateResponse
     {
-        return $this->stateService->isOnboardingState($useWidgets) ?
+        return $this->stateService->isOnboardingState() ?
             IntegrationUIStateResponse::onboarding() :
             IntegrationUIStateResponse::dashboard();
     }

--- a/src/BusinessLogic/AdminAPI/PromotionalWidgets/Requests/WidgetSettingsRequest.php
+++ b/src/BusinessLogic/AdminAPI/PromotionalWidgets/Requests/WidgetSettingsRequest.php
@@ -14,11 +14,7 @@ use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Models\WidgetSettings;
  */
 class WidgetSettingsRequest extends Request
 {
-    /**
-     * @var bool
-     */
-    protected $enabled;
-    /**
+     /**
      * @var bool
      */
     protected $displayOnProductPage;
@@ -75,12 +71,11 @@ class WidgetSettingsRequest extends Request
      */
     protected $widgetOnListingPage;
     /**
-     * @var array<string,string>
+     * @var array<string,string|bool>
      */
     protected $customLocations;
 
     /**
-     * @param bool $enabled
      * @param bool $displayOnProductPage
      * @param bool $showInstallmentsInProductListing
      * @param bool $showInstallmentsInCartPage
@@ -98,7 +93,6 @@ class WidgetSettingsRequest extends Request
      * @param array<string,string> $customLocations
      */
     public function __construct(
-        bool $enabled,
         bool $displayOnProductPage,
         bool $showInstallmentsInProductListing,
         bool $showInstallmentsInCartPage,
@@ -115,7 +109,6 @@ class WidgetSettingsRequest extends Request
         string $altProductPriceTriggerSelector = '',
         array $customLocations = []
     ) {
-        $this->enabled = $enabled;
         $this->displayOnProductPage = $displayOnProductPage;
         $this->showInstallmentsInProductListing = $showInstallmentsInProductListing;
         $this->showInstallmentsInCartPage = $showInstallmentsInCartPage;
@@ -161,7 +154,6 @@ class WidgetSettingsRequest extends Request
         $productWidgetSettings->setCustomWidgetsSettings($customLocationModels);
 
         return new WidgetSettings(
-            $this->enabled,
             $this->displayOnProductPage,
             $this->showInstallmentsInProductListing,
             $this->showInstallmentsInCartPage,

--- a/src/BusinessLogic/AdminAPI/PromotionalWidgets/Responses/WidgetSettingsResponse.php
+++ b/src/BusinessLogic/AdminAPI/PromotionalWidgets/Responses/WidgetSettingsResponse.php
@@ -35,7 +35,6 @@ class WidgetSettingsResponse extends Response
         }
 
         $widgetSettingsArray = [
-            'useWidgets' => $this->widgetSettings->isEnabled(),
             'displayWidgetOnProductPage' => $this->widgetSettings->isDisplayOnProductPage(),
             'showInstallmentAmountInProductListing' => $this->widgetSettings->isShowInstallmentsInProductListing(),
             'showInstallmentAmountInCartPage' => $this->widgetSettings->isShowInstallmentsInCartPage(),

--- a/src/BusinessLogic/DataAccess/PromotionalWidgets/Entities/WidgetSettings.php
+++ b/src/BusinessLogic/DataAccess/PromotionalWidgets/Entities/WidgetSettings.php
@@ -40,7 +40,6 @@ class WidgetSettings extends Entity
 
         $this->storeId = $data['storeId'] ?? '';
         $this->widgetSettings = new DomainWidgetSettings(
-            (bool)self::getArrayValue($widgetSettings, 'enabled', false),
             (bool)self::getArrayValue($widgetSettings, 'displayOnProductPage', false),
             (bool)self::getArrayValue($widgetSettings, 'showInstallmentsInProductListing', false),
             (bool)self::getArrayValue($widgetSettings, 'showInstallmentsInCartPage', false),
@@ -67,7 +66,6 @@ class WidgetSettings extends Entity
 
         $data['storeId'] = $this->storeId;
         $data['widgetSettings'] = [
-            'enabled' => $this->widgetSettings->isEnabled(),
             'displayOnProductPage' => $this->widgetSettings->isDisplayOnProductPage(),
             'showInstallmentsInProductListing' => $this->widgetSettings->isShowInstallmentsInProductListing(),
             'showInstallmentsInCartPage' => $this->widgetSettings->isShowInstallmentsInCartPage(),

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Models/WidgetSettings.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Models/WidgetSettings.php
@@ -12,10 +12,6 @@ class WidgetSettings
     /**
      * @var bool
      */
-    protected $enabled;
-    /**
-     * @var bool
-     */
     protected $displayOnProductPage;
     /**
      * @var bool
@@ -43,7 +39,6 @@ class WidgetSettings
     protected $widgetSettingsForListing;
 
     /**
-     * @param bool $enabled
      * @param bool $displayOnProductPage
      * @param bool $showInstallmentsInProductListing
      * @param bool $showInstallmentsInCartPage
@@ -53,7 +48,6 @@ class WidgetSettings
      * @param WidgetSelectorSettings|null $widgetSettingsForListing
      */
     public function __construct(
-        bool $enabled,
         bool $displayOnProductPage = false,
         bool $showInstallmentsInProductListing = false,
         bool $showInstallmentsInCartPage = false,
@@ -62,7 +56,6 @@ class WidgetSettings
         ?WidgetSelectorSettings $widgetSettingsForCart = null,
         ?WidgetSelectorSettings $widgetSettingsForListing = null
     ) {
-        $this->enabled = $enabled;
         $this->displayOnProductPage = $displayOnProductPage;
         $this->showInstallmentsInProductListing = $showInstallmentsInProductListing;
         $this->showInstallmentsInCartPage = $showInstallmentsInCartPage;
@@ -70,24 +63,6 @@ class WidgetSettings
         $this->widgetSettingsForProduct = $widgetSettingsForProduct;
         $this->widgetSettingsForCart = $widgetSettingsForCart;
         $this->widgetSettingsForListing = $widgetSettingsForListing;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEnabled(): bool
-    {
-        return $this->enabled;
-    }
-
-    /**
-     * @param bool $enabled
-     *
-     * @return void
-     */
-    public function setEnabled(bool $enabled): void
-    {
-        $this->enabled = $enabled;
     }
 
     /**

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
@@ -127,7 +127,7 @@ class WidgetSettingsService
     public function getWidgetInitializeData(string $shippingCountry, string $currentCountry): ?WidgetInitializer
     {
         $widgetSettings = $this->getWidgetSettings();
-        if (!$widgetSettings || !$widgetSettings->isEnabled()) {
+        if (!$widgetSettings) {
             return null;
         }
 
@@ -163,7 +163,7 @@ class WidgetSettingsService
     public function getAvailableWidgetForCartPage(string $shippingCountry, string $currentCountry): ?Widget
     {
         $widgetSettings = $this->getWidgetSettings();
-        if (!$widgetSettings || !$widgetSettings->isEnabled() || !$widgetSettings->isShowInstallmentsInCartPage()) {
+        if (!$widgetSettings || !$widgetSettings->isShowInstallmentsInCartPage()) {
             return null;
         }
 
@@ -209,7 +209,6 @@ class WidgetSettingsService
         $widgetSettings = $this->getWidgetSettings();
         if (
             !$widgetSettings ||
-            !$widgetSettings->isEnabled() ||
             !$widgetSettings->isShowInstallmentsInProductListing()
         ) {
             return null;
@@ -262,7 +261,7 @@ class WidgetSettingsService
     public function getAvailableWidgetsForProductPage(string $shippingCountry, string $currentCountry): array
     {
         $widgetSettings = $this->getWidgetSettings();
-        if (!$widgetSettings || !$widgetSettings->isEnabled() || !$widgetSettings->isDisplayOnProductPage()) {
+        if (!$widgetSettings || !$widgetSettings->isDisplayOnProductPage()) {
             return [];
         }
 

--- a/src/BusinessLogic/Domain/UIState/Services/UIStateService.php
+++ b/src/BusinessLogic/Domain/UIState/Services/UIStateService.php
@@ -56,24 +56,19 @@ class UIStateService
     /**
      * Returns true it the application state is onboarding.
      *
-     * @param bool $useWidgets
-     *
      * @return bool
      *
      * @throws Exception
      */
-    public function isOnboardingState(bool $useWidgets): bool
+    public function isOnboardingState(): bool
     {
         $allConnectionSettings = $this->connectionDataRepository->getAllConnectionSettings();
-
-        if ($useWidgets) {
-            $widgetSettings = $this->widgetSettingsRepository->getWidgetSettings();
-            if (!$widgetSettings) {
-                return true;
-            }
+        if (empty($allConnectionSettings)) {
+            return true;
         }
 
-        if (empty($allConnectionSettings)) {
+        $widgetConfig = $this->widgetSettingsRepository->getWidgetSettings();
+        if (!$widgetConfig) {
             return true;
         }
 

--- a/tests/BusinessLogic/AdminAPI/Integration/IntegrationControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/Integration/IntegrationControllerTest.php
@@ -122,7 +122,6 @@ class IntegrationControllerTest extends BaseTestCase
             true,
             true,
             true,
-            true,
             '.test'
         );
 

--- a/tests/BusinessLogic/AdminAPI/PromotionalWidgets/PromotionalWidgetsControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/PromotionalWidgets/PromotionalWidgetsControllerTest.php
@@ -46,7 +46,6 @@ class PromotionalWidgetsControllerTest extends BaseTestCase
     {
         // arrange
         $settings = new WidgetSettings(
-            true,
             false,
             false,
             false,
@@ -60,7 +59,6 @@ class PromotionalWidgetsControllerTest extends BaseTestCase
         // assert
         self::assertEquals(
             [
-                'useWidgets' => $settings->isEnabled(),
                 'displayWidgetOnProductPage' => $settings->isDisplayOnProductPage(),
                 'showInstallmentAmountInProductListing' => $settings->isShowInstallmentsInProductListing(),
                 'showInstallmentAmountInCartPage' => $settings->isShowInstallmentsInCartPage(),
@@ -74,7 +72,6 @@ class PromotionalWidgetsControllerTest extends BaseTestCase
     {
         // arrange
         $settings = new WidgetSettingsRequest(
-            false,
             false,
             true,
             true,

--- a/tests/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsServiceTest.php
+++ b/tests/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsServiceTest.php
@@ -782,7 +782,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             false,
             false,
@@ -826,7 +825,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             false,
             false,
@@ -918,7 +916,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             false,
             true,
@@ -1084,7 +1081,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             false,
             false,
@@ -1128,7 +1124,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             true,
             false,
@@ -1294,7 +1289,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             false,
             false,
             false,
@@ -1347,7 +1341,6 @@ class WidgetSettingsServiceTest extends BaseTestCase
             )
         );
         $this->widgetSettingsRepository->setWidgetSettings(new WidgetSettingsModel(
-            true,
             true,
             false,
             false,


### PR DESCRIPTION
### What is the goal?

- Remove “Would you like to use promotional widgets?” option from Widget Settings Admin UI.

 ### References
* **Issue:** [LIS-94](https://sequra.atlassian.net/browse/LIS-94)

 ### How is it being implemented?

- Removed enabled flag from WidgetSettings model, entity and services
- Removed useWidgets flag for determining the current UI state

### How is it tested?
- Unit tests

[LIS-94]: https://sequra.atlassian.net/browse/LIS-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ