### PR TITLE
Refactor StoreContext constructor to initialise storeId directly

### DIFF
--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -85,6 +85,7 @@ use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\RepositoryContracts\Widg
 use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Services\WidgetSettingsService;
 use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Services\WidgetValidationService;
 use SeQura\Core\BusinessLogic\Domain\Integration\PromotionalWidgets\MiniWidgetMessagesProviderInterface;
+use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreIdProvider;
 use SeQura\Core\BusinessLogic\Domain\SendReport\RepositoryContracts\SendReportRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\StatisticalData\RepositoryContracts\StatisticalDataRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\StatisticalData\Services\StatisticalDataService;
@@ -281,6 +282,10 @@ class BootstrapComponent extends BaseBootstrapComponent
 
         ServiceRegister::registerService(StoreContext::class, static function () {
             return StoreContext::getInstance();
+        });
+
+        ServiceRegister::registerService(StoreIdProvider::class, static function () {
+            return new StoreIdProvider();
         });
 
         ServiceRegister::registerService(

--- a/src/BusinessLogic/Domain/Integration/Store/StoreIdProvider.php
+++ b/src/BusinessLogic/Domain/Integration/Store/StoreIdProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Integration\Store;
+
+/**
+ * StoreIdProvider
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Integration\Store
+ */
+class StoreIdProvider
+{
+    /**
+     * Override to provide current store ID according to the platform context.
+     *
+     * @return string
+     */
+    public function getCurrentStoreId(): string
+    {
+        return '';
+    }
+}

--- a/src/BusinessLogic/Domain/Multistore/StoreContext.php
+++ b/src/BusinessLogic/Domain/Multistore/StoreContext.php
@@ -3,7 +3,7 @@
 namespace SeQura\Core\BusinessLogic\Domain\Multistore;
 
 use Exception;
-use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreServiceInterface;
+use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreIdProvider;
 use SeQura\Core\Infrastructure\ServiceRegister;
 
 /**
@@ -81,10 +81,9 @@ class StoreContext
     protected function setDefaultStoreId(): void
     {
         /**
-         * @var StoreServiceInterface $storeService
+         * @var StoreIdProvider $storeIdProvider
          */
-        $storeService = ServiceRegister::getService(StoreServiceInterface::class);
-        $defaultStore = $storeService->getDefaultStore();
-        $this->storeId = $defaultStore ? $defaultStore->getStoreId() : '';
+        $storeIdProvider = ServiceRegister::getService(StoreIdProvider::class);
+        $this->storeId = $storeIdProvider->getCurrentStoreId();
     }
 }

--- a/src/BusinessLogic/Domain/Multistore/StoreContext.php
+++ b/src/BusinessLogic/Domain/Multistore/StoreContext.php
@@ -28,6 +28,9 @@ class StoreContext
 
     protected function __construct()
     {
+        /**
+         * @var StoreServiceInterface $storeService
+         */
         $storeService = ServiceRegister::getService(StoreServiceInterface::class);
         $defaultStore = $storeService->getDefaultStore();
         $this->storeId = $defaultStore ? $defaultStore->getStoreId() : '';

--- a/src/BusinessLogic/Domain/Multistore/StoreContext.php
+++ b/src/BusinessLogic/Domain/Multistore/StoreContext.php
@@ -28,12 +28,7 @@ class StoreContext
 
     protected function __construct()
     {
-        /**
-         * @var StoreServiceInterface $storeService
-         */
-        $storeService = ServiceRegister::getService(StoreServiceInterface::class);
-        $defaultStore = $storeService->getDefaultStore();
-        $this->storeId = $defaultStore ? $defaultStore->getStoreId() : '';
+        $this->setDefaultStoreId();
     }
 
     public static function getInstance(): StoreContext
@@ -78,5 +73,18 @@ class StoreContext
     public function getStoreId(): string
     {
         return $this->storeId;
+    }
+
+    /**
+     * Sets the default store ID.
+     */
+    protected function setDefaultStoreId(): void
+    {
+        /**
+         * @var StoreServiceInterface $storeService
+         */
+        $storeService = ServiceRegister::getService(StoreServiceInterface::class);
+        $defaultStore = $storeService->getDefaultStore();
+        $this->storeId = $defaultStore ? $defaultStore->getStoreId() : '';
     }
 }

--- a/src/BusinessLogic/Domain/Multistore/StoreContext.php
+++ b/src/BusinessLogic/Domain/Multistore/StoreContext.php
@@ -3,6 +3,8 @@
 namespace SeQura\Core\BusinessLogic\Domain\Multistore;
 
 use Exception;
+use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreServiceInterface;
+use SeQura\Core\Infrastructure\ServiceRegister;
 
 /**
  * Class StoreContext
@@ -22,10 +24,13 @@ class StoreContext
     /**
      * @var string
      */
-    protected $storeId = '';
+    protected $storeId;
 
     protected function __construct()
     {
+        $storeService = ServiceRegister::getService(StoreServiceInterface::class);
+        $defaultStore = $storeService->getDefaultStore();
+        $this->storeId = $defaultStore ? $defaultStore->getStoreId() : '';
     }
 
     public static function getInstance(): StoreContext

--- a/tests/BusinessLogic/AdminAPI/OrderStatusSettings/OrderStatusSettingsControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/OrderStatusSettings/OrderStatusSettingsControllerTest.php
@@ -360,7 +360,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testApprovedStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('');
+        $mapping->setStoreId('1');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),
@@ -384,7 +384,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testReviewStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('');
+        $mapping->setStoreId('1');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),
@@ -407,7 +407,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testCancelledStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('');
+        $mapping->setStoreId('1');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),

--- a/tests/BusinessLogic/AdminAPI/OrderStatusSettings/OrderStatusSettingsControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/OrderStatusSettings/OrderStatusSettingsControllerTest.php
@@ -360,7 +360,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testApprovedStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('1');
+        $mapping->setStoreId('');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),
@@ -384,7 +384,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testReviewStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('1');
+        $mapping->setStoreId('');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),
@@ -407,7 +407,7 @@ class OrderStatusSettingsControllerTest extends BaseTestCase
     public function testCancelledStatusMapping(): void
     {
         $mapping = new OrderStatusSettings();
-        $mapping->setStoreId('1');
+        $mapping->setStoreId('');
         $mapping->setOrderStatusMappings([
             new OrderStatusMapping(OrderStates::STATE_APPROVED, 'Success'),
             new OrderStatusMapping(OrderStates::STATE_CANCELLED, 'Failed'),

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -61,6 +61,7 @@ use SeQura\Core\BusinessLogic\Domain\Integration\PromotionalWidgets\MiniWidgetMe
 use SeQura\Core\BusinessLogic\Domain\Integration\PromotionalWidgets\WidgetConfiguratorInterface;
 use SeQura\Core\BusinessLogic\Domain\Integration\SellingCountries\SellingCountriesServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Integration\ShopOrderStatuses\ShopOrderStatusesServiceInterface;
+use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreIdProvider;
 use SeQura\Core\BusinessLogic\Domain\Integration\Store\StoreServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Integration\Version\VersionServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Merchant\ProxyContracts\MerchantProxyInterface;
@@ -130,7 +131,6 @@ use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockMerchantDataProvid
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockOrderCreation;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockProductService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockMiniWidgetMessagesProvider;
-use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockStoreService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockWidgetConfigurator;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\TestEncryptor;
 use SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents\MockShopOrderService;
@@ -183,8 +183,8 @@ class BaseTestCase extends TestCase
             HttpClient::class => function () {
                 return new TestHttpClient();
             },
-            StoreServiceInterface::class => function () {
-                return new MockStoreService();
+            StoreIdProvider::class => function () {
+                return new StoreIdProvider();
             },
             StoreContext::class => function () {
                 return StoreContext::getInstance();

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -130,6 +130,7 @@ use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockMerchantDataProvid
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockOrderCreation;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockProductService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockMiniWidgetMessagesProvider;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockStoreService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockWidgetConfigurator;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\TestEncryptor;
 use SeQura\Core\Tests\BusinessLogic\WebhookAPI\MockComponents\MockShopOrderService;
@@ -181,6 +182,9 @@ class BaseTestCase extends TestCase
             },
             HttpClient::class => function () {
                 return new TestHttpClient();
+            },
+            StoreServiceInterface::class => function () {
+                return new MockStoreService();
             },
             StoreContext::class => function () {
                 return StoreContext::getInstance();


### PR DESCRIPTION
 ### What is the goal?

Initialise `StoreContext`  with the default store ID value so any service that depends on `StoreContext` will have the correct store ID set from the beginning. This will reduce the `StoreContext::doWithStore` calls to the cases where it's really necessary to set a different store ID on runtime.

 ### References
* **Issue:** PAR-611

 ### How is it being implemented?

This pull request updates the initialization logic for the `StoreContext` class to dynamically set the default store ID using a registered store service, instead of hardcoding it. This change improves flexibility and integration with the store infrastructure.

**Store context initialization improvements:**

* The constructor of `StoreContext` now retrieves the default store from the `StoreServiceInterface` via the `ServiceRegister`, and sets `storeId` to the default store's ID if available, otherwise to an empty string.
* Added imports for `StoreServiceInterface` and `ServiceRegister` to support the new initialization logic.

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment