### PR TITLE
Use merchant in the response instead of merchantId

### DIFF
--- a/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/PromotionalWidgets/Responses/PromotionalWidgetsCheckoutResponse.php
@@ -35,7 +35,7 @@ class PromotionalWidgetsCheckoutResponse extends Response
 
         return [
             'assetKey' => $this->widgetInitializer->getAssetKey(),
-            'merchantId' => $this->widgetInitializer->getMerchantId(),
+            'merchant' => $this->widgetInitializer->getMerchantId(),
             'products' => $this->widgetInitializer->getProducts(),
             'scriptUri' => $this->widgetInitializer->getScriptUri(),
             'locale' => $this->widgetInitializer->getLocale(),

--- a/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/PromotionalWidgets/PromotionalWidgetsApiTest.php
@@ -141,7 +141,7 @@ class PromotionalWidgetsApiTest extends BaseTestCase
         //Assert
         self::assertEquals([
             'assetKey' => 'assets1',
-            'merchantId' => 'merchant1',
+            'merchant' => 'merchant1',
             'products' => ['product1', 'product2'],
             'scriptUri' => 'testScriptUri.com',
             'locale' => 'es',


### PR DESCRIPTION
 ### What is the goal?

Make the response field names more consistent.
Now that we are goin to release the 3.0.0 it the moment to add pending changes that break backward compatibility.

 ### References
* **Issue:** #37
