### PR TITLE
PAR-768: Restore skip guard for redundant store integration calls

### DIFF
--- a/src/BusinessLogic/Domain/Connection/Services/ConnectionService.php
+++ b/src/BusinessLogic/Domain/Connection/Services/ConnectionService.php
@@ -70,7 +70,7 @@ class ConnectionService
             try {
                 $credentials = $this->credentialsService->validateAndUpdateCredentials($connectionData);
                 $this->credentialsService->updateCountryConfigurationWithNewMerchantIdsAndRemoveOldPaymentMethods($credentials);
-                $this->registerWebhooks($connectionData);
+                $this->registerWebhooks($connectionData, true);
                 $this->saveConnectionData($connectionData);
             } catch (WrongCredentialsException $exception) {
                 $errors[] = $connectionData->getDeployment();
@@ -201,13 +201,14 @@ class ConnectionService
 
     /**
      * @param ConnectionData $connectionData
+     * @param bool $skipIfExists When true, skips the HTTP call if a local record already exists.
      *
      * @return void
      *
      * @throws CapabilitiesEmptyException
      */
-    protected function registerWebhooks(ConnectionData $connectionData): void
+    protected function registerWebhooks(ConnectionData $connectionData, bool $skipIfExists = false): void
     {
-        $this->storeIntegrationService->createStoreIntegration($connectionData);
+        $this->storeIntegrationService->createStoreIntegration($connectionData, $skipIfExists);
     }
 }

--- a/src/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationService.php
+++ b/src/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationService.php
@@ -67,13 +67,23 @@ class StoreIntegrationService
      * Creates store integration.
      *
      * @param ConnectionData $connectionData
+     * @param bool $skipIfExists When true, skips the HTTP call if connection data for the
+     *                           same deployment is already persisted (proxy for "integration
+     *                           already created remotely").
      *
      * @return void
      *
      * @throws CapabilitiesEmptyException
      */
-    public function createStoreIntegration(ConnectionData $connectionData): void
+    public function createStoreIntegration(ConnectionData $connectionData, bool $skipIfExists = false): void
     {
+        if (
+            $skipIfExists
+            && $this->connectionDataRepository->getConnectionDataByDeploymentId($connectionData->getDeployment()) !== null
+        ) {
+            return;
+        }
+
         $signature = $this->computeSignature($connectionData);
         $webhookUrl = $this->buildWebhookUrl($this->integrationService->getWebhookUrl(), $signature);
         $capabilities = $this->getSupportedCapabilities();

--- a/tests/BusinessLogic/Common/MockComponents/MockStoreIntegrationService.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockStoreIntegrationService.php
@@ -30,10 +30,11 @@ class MockStoreIntegrationService extends StoreIntegrationService
 
     /**
      * @param ConnectionData $connectionData
+     * @param bool $skipIfExists
      *
      * @return void
      */
-    public function createStoreIntegration(ConnectionData $connectionData): void
+    public function createStoreIntegration(ConnectionData $connectionData, bool $skipIfExists = false): void
     {
         $this->createdIntegrationIds[$connectionData->getMerchantId()] = true;
     }

--- a/tests/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationServiceTest.php
+++ b/tests/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationServiceTest.php
@@ -124,6 +124,89 @@ class StoreIntegrationServiceTest extends BaseTestCase
      *
      * @throws CapabilitiesEmptyException
      * @throws InvalidEnvironmentException
+     */
+    public function testCreateStoreIntegrationSkippedWhenExistingAndSkipIfExistsTrue(): void
+    {
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $connectionData = new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        );
+        $this->connectionDataRepository->setConnectionData($connectionData);
+
+        $this->service->createStoreIntegration($connectionData, true);
+
+        self::assertEquals(0, $this->storeIntegrationProxy->getCreateCallCount());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     */
+    public function testCreateStoreIntegrationCalledWhenExistingAndSkipIfExistsFalse(): void
+    {
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('newId'));
+        $connectionData = new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        );
+        $this->connectionDataRepository->setConnectionData($connectionData);
+
+        $this->service->createStoreIntegration($connectionData, false);
+
+        self::assertEquals(1, $this->storeIntegrationProxy->getCreateCallCount());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     */
+    public function testCreateStoreIntegrationCalledWhenNoExistingAndSkipIfExistsTrue(): void
+    {
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('newId'));
+
+        $this->service->createStoreIntegration(
+            new ConnectionData('sandbox', 'merchant', 'svea', new AuthorizationCredentials('username', 'password')),
+            true
+        );
+
+        self::assertEquals(1, $this->storeIntegrationProxy->getCreateCallCount());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     */
+    public function testCreateStoreIntegrationCalledWhenNoExistingAndSkipIfExistsFalse(): void
+    {
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('newId'));
+
+        $this->service->createStoreIntegration(
+            new ConnectionData('sandbox', 'merchant', 'svea', new AuthorizationCredentials('username', 'password')),
+            false
+        );
+
+        self::assertEquals(1, $this->storeIntegrationProxy->getCreateCallCount());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
      * @throws InvalidUrlException
      */
     public function testCreateStoreQueries(): void


### PR DESCRIPTION
## Summary

- Restores PAR-768's redundant-call guard (originally merged in #53) which was silently undone by PAR-772 (#54). The big signature redesign removed the `StoreIntegration` entity/repository, which is what the guard relied on.
- Re-adds `bool $skipIfExists` to `StoreIntegrationService::createStoreIntegration()` (and to `ConnectionService::registerWebhooks()` / `MockStoreIntegrationService`). The guard now keys on `ConnectionDataRepositoryInterface::getConnectionDataByDeploymentId()` as the proxy for "integration already created remotely" — the dedicated local `StoreIntegration` record no longer exists, but `ConnectionData` is persisted only after a successful first connect, so it works the same.
- Fixes a wiring bug from the original `26b3f45`: `ConnectionService::connect()` now passes `true` (opt into the guard), not `false`. With `false` the parameter was inert, so the merged commit didn't actually prevent any redundant calls. The PR description on #53 explicitly stated `connect()` should opt into the guard, so this matches the original intent.

## What changed
- `ConnectionService::connect()` — passes `true` to skip the second `POST /store_integrations` on reconnects.
- `ConnectionService::registerWebhooks()` — accepts `$skipIfExists` and forwards it.
- `StoreIntegrationService::createStoreIntegration()` — early-returns when `$skipIfExists && $connectionDataRepository->getConnectionDataByDeploymentId(...) !== null`.
- `MockStoreIntegrationService::createStoreIntegration()` — signature kept in sync.
- 4 new unit tests covering existing/no-existing × `skipIfExists` true/false.

## Why not just cherry-pick #53?
The original guard inspected `storeIntegrationRepository->getStoreIntegration()`, but PAR-772 deleted that entity, repository, and interface as part of the HMAC redesign. A literal cherry-pick conflicts and would re-introduce dead storage. This PR adapts the guard to the post-#54 architecture.

## Test plan
- [x] `vendor/bin/phpunit` — all 760 tests pass (PHP 7.2 via docker container).
- [x] `vendor/bin/phpcs --standard=.phpcs.xml.dist` — clean.
- [x] `vendor/bin/phpstan analyse src/` — no errors.
- [ ] Reviewer to sanity-check that `connect()` passing `true` matches the intended behavior on a fresh install (first connect: no `ConnectionData` yet → guard does not trigger → API call happens → `ConnectionData` saved → subsequent connects skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)