### PR TITLE
PAR-782: Ignore Unsupported Countries In Configuration

### DIFF
--- a/src/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationController.php
+++ b/src/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationController.php
@@ -8,7 +8,6 @@ use SeQura\Core\BusinessLogic\AdminAPI\CountryConfiguration\Responses\SellingCou
 use SeQura\Core\BusinessLogic\AdminAPI\CountryConfiguration\Responses\SuccessfulCountryConfigurationResponse;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\FailedToRetrieveSellingCountriesException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\CountryConfigurationService;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\SellingCountriesService;
 
@@ -73,7 +72,6 @@ class CountryConfigurationController
      * @return SuccessfulCountryConfigurationResponse
      *
      * @throws EmptyCountryConfigurationParameterException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function saveCountryConfigurations(CountryConfigurationRequest $request): SuccessfulCountryConfigurationResponse
     {

--- a/src/BusinessLogic/AdminAPI/CountryConfiguration/Requests/CountryConfigurationRequest.php
+++ b/src/BusinessLogic/AdminAPI/CountryConfiguration/Requests/CountryConfigurationRequest.php
@@ -4,7 +4,6 @@ namespace SeQura\Core\BusinessLogic\AdminAPI\CountryConfiguration\Requests;
 
 use SeQura\Core\BusinessLogic\AdminAPI\Request\Request;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
 
 /**
@@ -32,7 +31,6 @@ class CountryConfigurationRequest extends Request
      *
      * @return CountryConfiguration[]
      *
-     * @throws InvalidCountryCodeForConfigurationException
      * @throws EmptyCountryConfigurationParameterException
      */
     public function transformToDomainModel(): array

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/GeneralSettings/SaveGeneralSettingsHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/GeneralSettings/SaveGeneralSettingsHandler.php
@@ -9,7 +9,6 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\GeneralSettings\S
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\GeneralSettings\SaveGeneralSettingsResponse;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\FailedToRetrieveSellingCountriesException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\CountryConfigurationService;
 use SeQura\Core\BusinessLogic\Domain\GeneralSettings\Services\GeneralSettingsService;
 
@@ -49,7 +48,6 @@ class SaveGeneralSettingsHandler implements TopicHandlerInterface
      *
      * @throws EmptyCountryConfigurationParameterException
      * @throws FailedToRetrieveSellingCountriesException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function handle(array $payload): Response
     {

--- a/src/BusinessLogic/DataAccess/CountryConfiguration/Entities/CountryConfiguration.php
+++ b/src/BusinessLogic/DataAccess/CountryConfiguration/Entities/CountryConfiguration.php
@@ -3,7 +3,6 @@
 namespace SeQura\Core\BusinessLogic\DataAccess\CountryConfiguration\Entities;
 
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration as DomainCountryConfiguration;
 use SeQura\Core\Infrastructure\ORM\Configuration\EntityConfiguration;
 use SeQura\Core\Infrastructure\ORM\Configuration\IndexMap;
@@ -34,7 +33,6 @@ class CountryConfiguration extends Entity
     /**
      * @inheritDoc
      *
-     * @throws InvalidCountryCodeForConfigurationException
      * @throws EmptyCountryConfigurationParameterException
      */
     public function inflate(array $data): void

--- a/src/BusinessLogic/Domain/CountryConfiguration/Exceptions/InvalidCountryCodeForConfigurationException.php
+++ b/src/BusinessLogic/Domain/CountryConfiguration/Exceptions/InvalidCountryCodeForConfigurationException.php
@@ -8,6 +8,9 @@ use SeQura\Core\BusinessLogic\Domain\Translations\Model\BaseTranslatableExceptio
  * Class InvalidCountryCodeForConfigurationException
  *
  * @package SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions
+ *
+ * @deprecated No longer thrown by integration-core (see PAR-782). Class retained for backwards compatibility
+ * with downstream plugins that catch it; will be removed in a future major release.
  */
 class InvalidCountryCodeForConfigurationException extends BaseTranslatableException
 {

--- a/src/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfiguration.php
+++ b/src/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfiguration.php
@@ -2,9 +2,7 @@
 
 namespace SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models;
 
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Enum\SellingCountries;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\Translations\Model\TranslatableLabel;
 
 /**
@@ -28,7 +26,6 @@ class CountryConfiguration
      * @param string $countryCode
      * @param string $merchantId
      *
-     * @throws InvalidCountryCodeForConfigurationException
      * @throws EmptyCountryConfigurationParameterException
      */
     public function __construct(string $countryCode, string $merchantId)
@@ -36,12 +33,6 @@ class CountryConfiguration
         if (empty($countryCode) || empty($merchantId)) {
             throw new EmptyCountryConfigurationParameterException(
                 new TranslatableLabel('Country configuration parameter cannot be an empty string.', 'general.errors.countries.empty')
-            );
-        }
-
-        if (!array_key_exists($countryCode, SellingCountries::SELLING_COUNTRIES)) {
-            throw new InvalidCountryCodeForConfigurationException(
-                new TranslatableLabel('Invalid country code in the country configuration.', 'general.errors.countries.countryCode')
             );
         }
 

--- a/src/BusinessLogic/Domain/CountryConfiguration/Services/CountryConfigurationService.php
+++ b/src/BusinessLogic/Domain/CountryConfiguration/Services/CountryConfigurationService.php
@@ -4,7 +4,6 @@ namespace SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services;
 
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\FailedToRetrieveSellingCountriesException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\SellingCountry;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\RepositoryContracts\CountryConfigurationRepositoryInterface;
@@ -81,7 +80,6 @@ class CountryConfigurationService
      *
      * @throws FailedToRetrieveSellingCountriesException
      * @throws EmptyCountryConfigurationParameterException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function saveCountryConfigurationForCountriesCodes(array $countriesCodes): void
     {

--- a/tests/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationControllerTest.php
@@ -11,7 +11,6 @@ use SeQura\Core\BusinessLogic\AdminAPI\CountryConfiguration\Responses\Successful
 use SeQura\Core\BusinessLogic\Domain\Connection\Services\ConnectionService;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\FailedToRetrieveSellingCountriesException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\SellingCountry;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\RepositoryContracts\CountryConfigurationRepositoryInterface;
@@ -246,7 +245,6 @@ class CountryConfigurationControllerTest extends BaseTestCase
 
     /**
      * @throws EmptyCountryConfigurationParameterException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function testIsSaveResponseSuccessful(): void
     {
@@ -275,7 +273,6 @@ class CountryConfigurationControllerTest extends BaseTestCase
 
     /**
      * @throws EmptyCountryConfigurationParameterException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function testSaveResponse(): void
     {
@@ -305,7 +302,6 @@ class CountryConfigurationControllerTest extends BaseTestCase
 
     /**
      * @throws EmptyCountryConfigurationParameterException
-     * @throws InvalidCountryCodeForConfigurationException
      */
     public function testSaveResponseToArray(): void
     {

--- a/tests/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationControllerTest.php
+++ b/tests/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationControllerTest.php
@@ -329,6 +329,26 @@ class CountryConfigurationControllerTest extends BaseTestCase
     }
 
     /**
+     * @throws EmptyCountryConfigurationParameterException
+     */
+    public function testSaveResponseAcceptsUnsupportedCountryCode(): void
+    {
+        // Arrange
+        $countryConfigurationRequest = new CountryConfigurationRequest([
+            [
+                'countryCode' => 'MX',
+                'merchantId' => 'logeecom',
+            ]
+        ]);
+
+        // Act
+        $response = AdminAPI::get()->countryConfiguration('1')->saveCountryConfigurations($countryConfigurationRequest);
+
+        // Assert
+        self::assertTrue($response->isSuccessful());
+    }
+
+    /**
      * @throws Exception
      */
     public function testIsUpdateResponseSuccessful(): void

--- a/tests/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfigurationModelTest.php
+++ b/tests/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfigurationModelTest.php
@@ -27,12 +27,12 @@ class CountryConfigurationModelTest extends BaseTestCase
         new CountryConfiguration('', 'test');
     }
 
-    public function testUnsupportedCountryCodeIsAccepted(): void
+    public function testUnsupportedCountryCode(): void
     {
-        $countryConfiguration = new CountryConfiguration('MX', 'merchant');
+        $countryConfiguration = new CountryConfiguration('MX', 'logeecom');
 
         self::assertEquals('MX', $countryConfiguration->getCountryCode());
-        self::assertEquals('merchant', $countryConfiguration->getMerchantId());
+        self::assertEquals('logeecom', $countryConfiguration->getMerchantId());
     }
 
     public function testSettersAndGetters(): void

--- a/tests/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfigurationModelTest.php
+++ b/tests/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfigurationModelTest.php
@@ -3,7 +3,6 @@
 namespace SeQura\Core\Tests\BusinessLogic\Domain\CountryConfiguration\Models;
 
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
-use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
 use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
 
@@ -28,11 +27,12 @@ class CountryConfigurationModelTest extends BaseTestCase
         new CountryConfiguration('', 'test');
     }
 
-    public function testInvalidCountryCode(): void
+    public function testUnsupportedCountryCodeIsAccepted(): void
     {
-        $this->expectException(InvalidCountryCodeForConfigurationException::class);
+        $countryConfiguration = new CountryConfiguration('MX', 'merchant');
 
-        new CountryConfiguration('test', 'test');
+        self::assertEquals('MX', $countryConfiguration->getCountryCode());
+        self::assertEquals('merchant', $countryConfiguration->getMerchantId());
     }
 
     public function testSettersAndGetters(): void


### PR DESCRIPTION
### What is the goal?

Drop the `SELLING_COUNTRIES` whitelist check from `CountryConfiguration::__construct`. Keep the empty-string check. The existing read-time filter (against the integration-supplied selling-countries list) continues to ensure unsupported countries never surface to consumers, while writes no longer reject them.

### References
* **Issue:** [PAR-782](https://sequra.atlassian.net/browse/PAR-782)

### How is it being implemented?

**Affected files**

Production:
- `src/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfiguration.php` — removed the `SELLING_COUNTRIES` whitelist check and unused imports/`@throws`.
- `src/BusinessLogic/Domain/CountryConfiguration/Exceptions/InvalidCountryCodeForConfigurationException.php` — annotated `@deprecated` (class kept for BC; no longer thrown by integration-core).
- `src/BusinessLogic/AdminAPI/CountryConfiguration/Requests/CountryConfigurationRequest.php` — dropped stale `@throws` and import.
- `src/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationController.php` — dropped stale `@throws` and import.
- `src/BusinessLogic/Domain/CountryConfiguration/Services/CountryConfigurationService.php` — dropped stale `@throws` on `saveCountryConfigurationForCountriesCodes` and import.
- `src/BusinessLogic/ConfigurationWebhookAPI/Handlers/GeneralSettings/SaveGeneralSettingsHandler.php` — dropped stale `@throws` and import.
- `src/BusinessLogic/DataAccess/CountryConfiguration/Entities/CountryConfiguration.php` — dropped stale `@throws` on `inflate` and import.

Untouched:
- `SellingCountries::SELLING_COUNTRIES` — constant retained for display-name lookup in `SellingCountriesService`.

Tests:
- `tests/BusinessLogic/Domain/CountryConfiguration/Models/CountryConfigurationModelTest.php` — replaced `testInvalidCountryCode` with `testUnsupportedCountryCode` (asserts the constructor accepts `'MX'` and stores both fields).
- `tests/BusinessLogic/AdminAPI/CountryConfiguration/CountryConfigurationControllerTest.php` — removed stale `@throws` annotations + unused import; added `testSaveResponseAcceptsUnsupportedCountryCode` exercising the AdminAPI propagation chain (Request → Controller → Service → Repository) with `'MX'`.

**Risks & decisions**

- Persistence of unknown codes is now possible. Reads filter via `CountryConfigurationService::getCountryConfiguration` so consumers never see them; storage impact is nil.
- Raw-repository readers (`OrderReporter`, `CredentialsService::updateCountryConfigurationWithNewMerchantIdsAndRemoveOldPaymentMethods`, `DisconnectService::removeAllDeploymentData`) bypass the service-level filter but treat country code as opaque. Behavior unchanged.
- External plugins catching `InvalidCountryCodeForConfigurationException` still compile (class kept and now `@deprecated`); the catch becomes dead code and can be removed at the plugin's own pace.
- The translation key `general.errors.countries.countryCode` is no longer referenced by integration-core. Plugin teams may remove their entries on their own cadence.
- Filter-at-call-sites and extending `SELLING_COUNTRIES` were considered and rejected: the model invariant duplicated a read-time filter already enforced by the service; entity `inflate` has no clean access to the integration's selling-list service; extending the list is brittle and keeps drifting whenever sandbox enables a new country.

**Plan executed**

1. Remove the `SELLING_COUNTRIES` whitelist check and related imports/`@throws` from `CountryConfiguration::__construct`.
2. Update `CountryConfigurationModelTest` — delete `testInvalidCountryCode`, add `testUnsupportedCountryCode`.
3. Clean up stale `@throws InvalidCountryCodeForConfigurationException` annotations and unused imports in the propagation chain.
4. Clean up stale `@throws` annotations on `CountryConfigurationControllerTest` docblocks.
5. Run the QA pipeline (`./bin/phpunit`, `./bin/phpcs`, `./bin/phpstan`).
6. Mark the exception class `@deprecated` and add a controller-level regression test that drives `'MX'` through the full AdminAPI save chain.

### How is it going to be deployed?

Standard deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAR-782]: https://sequra.atlassian.net/browse/PAR-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ