### PR TITLE
PAR-789: PHP 8.5 Compatibility

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -54,6 +54,9 @@ jobs:
     - name: PHP 8.4 Syntax check
       run: docker run --rm -v "$(pwd)":/app -w /app php:8.4-cli-alpine sh -c "! (find . -type f -name \"*.php\" ! -path \"./tests/*\" ! -path \"./vendor/*\" -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
 
+    - name: PHP 8.5 Syntax check
+      run: docker run --rm -v "$(pwd)":/app -w /app php:8.5-cli-alpine sh -c "! (find . -type f -name \"*.php\" ! -path \"./tests/*\" ! -path \"./vendor/*\" -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
+
     - name: PHP_CodeSniffer
       run: docker run --rm -v "$(pwd)":/app -w /app php:7.2-cli-alpine php vendor/bin/phpcs --standard=.phpcs.xml.dist --warning-severity=0 . # Ignore Warnings for now...
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -41,4 +41,12 @@
 		<exclude-pattern>tests/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
 	</rule>
+	<!-- Require opcache-specialized functions (is_*, count, in_array, sprintf, ...)
+	     to be called with a leading `\` so the compiler can specialize the call site. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions">
+		<properties>
+			<property name="includeSpecialFunctions" value="true"/>
+		</properties>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.5.14",
-    "phpcompatibility/php-compatibility": "*",
+    "phpcompatibility/php-compatibility": "^9.3",
     "phpstan/phpstan": "^1.12 || ^2.1"
   },
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "require-dev": {
     "phpunit/phpunit": "8.5.14",
     "phpcompatibility/php-compatibility": "^9.3",
-    "phpstan/phpstan": "^1.12 || ^2.1"
+    "phpstan/phpstan": "^1.12 || ^2.1",
+    "slevomat/coding-standard": "^7.0"
   },
   "prefer-stable": true,
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,84 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31ecd95acd091a3c9dc9a1a7e4c8e2b1",
+    "content-hash": "ce9c6c746d224c1f5a978bf7ea92aa7e",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
@@ -546,6 +621,53 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.21.0"
             },
             "time": "2025-04-29T11:13:33+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/82a311fd3690fb2bf7b64d5c98f912b3dd746140",
+                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.33.0"
+            },
+            "time": "2024-10-13T11:25:22+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -1726,6 +1848,67 @@
                 "source": "https://github.com/sebastianbergmann/version/tree/master"
             },
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-25T10:58:12+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c1431b28cb3056336c9497f50c65624",
+    "content-hash": "31ecd95acd091a3c9dc9a1a7e4c8e2b1",
     "packages": [],
     "packages-dev": [
         {

--- a/src/BusinessLogic/AdminAPI/Aspects/ErrorHandlingAspect.php
+++ b/src/BusinessLogic/AdminAPI/Aspects/ErrorHandlingAspect.php
@@ -28,14 +28,14 @@ class ErrorHandlingAspect implements Aspect
     public function applyOn(callable $callee, array $params = [])
     {
         try {
-            $response = call_user_func_array($callee, $params);
+            $response = \call_user_func_array($callee, $params);
         } catch (BaseTranslatableException $e) {
             Logger::logError(
                 $e->getMessage(),
                 'Core',
                 [
                     new LogContextData('message', $e->getMessage()),
-                    new LogContextData('type', get_class($e)),
+                    new LogContextData('type', \get_class($e)),
                     new LogContextData('trace', $e->getTraceAsString()),
                 ]
             );
@@ -47,7 +47,7 @@ class ErrorHandlingAspect implements Aspect
                 'Core',
                 [
                     new LogContextData('message', $e->getMessage()),
-                    new LogContextData('type', get_class($e)),
+                    new LogContextData('type', \get_class($e)),
                     new LogContextData('trace', $e->getTraceAsString()),
                 ]
             );
@@ -59,7 +59,7 @@ class ErrorHandlingAspect implements Aspect
                 'Core',
                 [
                     new LogContextData('message', $e->getMessage()),
-                    new LogContextData('type', get_class($e)),
+                    new LogContextData('type', \get_class($e)),
                     new LogContextData('trace', $e->getTraceAsString()),
                 ]
             );
@@ -71,7 +71,7 @@ class ErrorHandlingAspect implements Aspect
                 'Core',
                 [
                     new LogContextData('message', $e->getMessage()),
-                    new LogContextData('type', get_class($e)),
+                    new LogContextData('type', \get_class($e)),
                     new LogContextData('trace', $e->getTraceAsString()),
                 ]
             );

--- a/src/BusinessLogic/AdminAPI/PaymentMethods/Responses/FormattedPaymentMethodsResponse.php
+++ b/src/BusinessLogic/AdminAPI/PaymentMethods/Responses/FormattedPaymentMethodsResponse.php
@@ -40,7 +40,7 @@ class FormattedPaymentMethodsResponse extends Response
             ));
 
             $category = $paymentMethod->getCategory();
-            if (!in_array($category, $supportedCategories, true)) {
+            if (!\in_array($category, $supportedCategories, true)) {
                 continue;
             }
 

--- a/src/BusinessLogic/Bootstrap/Aspect/Aspects.php
+++ b/src/BusinessLogic/Bootstrap/Aspect/Aspects.php
@@ -90,7 +90,7 @@ class Aspects
         return $this->aspect->applyOn(function () use ($methodName, $arguments) {
             $subject = ServiceRegister::getService($this->subjectClassName);
 
-            return call_user_func_array([$subject, $methodName], $arguments);
+            return \call_user_func_array([$subject, $methodName], $arguments);
         });
     }
 }

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/SellingCountries/GetSellingCountriesHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/SellingCountries/GetSellingCountriesHandler.php
@@ -49,7 +49,7 @@ class GetSellingCountriesHandler implements TopicHandlerInterface
             });
         }
         $items = array_values($items);
-        $paginatedItems = array_slice($items, ($page - 1) * $limit, $limit);
+        $paginatedItems = \array_slice($items, ($page - 1) * $limit, $limit);
 
         $data = array_map(function ($item) {
             return $item->getCode();

--- a/src/BusinessLogic/DataAccess/GeneralSettings/Entities/GeneralSettings.php
+++ b/src/BusinessLogic/DataAccess/GeneralSettings/Entities/GeneralSettings.php
@@ -48,7 +48,7 @@ class GeneralSettings extends Entity
             self::getDataValue($generalSettings, 'enabledForServices', []),
             self::getDataValue($generalSettings, 'allowFirstServicePaymentDelay', []),
             self::getDataValue($generalSettings, 'allowServiceRegistrationItems', []),
-            is_string($defaultServicesEndDate) ? $defaultServicesEndDate : null
+            \is_string($defaultServicesEndDate) ? $defaultServicesEndDate : null
         );
     }
 

--- a/src/BusinessLogic/Domain/Connection/Models/ConnectionData.php
+++ b/src/BusinessLogic/Domain/Connection/Models/ConnectionData.php
@@ -47,7 +47,7 @@ class ConnectionData extends DataTransferObject
         string $deployment,
         AuthorizationCredentials $authorizationCredentials
     ) {
-        if (!in_array($environment, [BaseProxy::LIVE_MODE, BaseProxy::TEST_MODE], true)) {
+        if (!\in_array($environment, [BaseProxy::LIVE_MODE, BaseProxy::TEST_MODE], true)) {
             throw new InvalidEnvironmentException();
         }
 

--- a/src/BusinessLogic/Domain/Connection/Models/Credentials.php
+++ b/src/BusinessLogic/Domain/Connection/Models/Credentials.php
@@ -180,9 +180,9 @@ class Credentials extends DataTransferObject
      */
     private function hasContractOption(string $option): bool
     {
-        if (!isset($this->payload['contract_options']) || !is_array($this->payload['contract_options'])) {
+        if (!isset($this->payload['contract_options']) || !\is_array($this->payload['contract_options'])) {
             return false;
         }
-        return in_array($option, $this->payload['contract_options'], true);
+        return \in_array($option, $this->payload['contract_options'], true);
     }
 }

--- a/src/BusinessLogic/Domain/Connection/Services/CredentialsService.php
+++ b/src/BusinessLogic/Domain/Connection/Services/CredentialsService.php
@@ -111,7 +111,7 @@ class CredentialsService
         }
 
         foreach ($countryConfigurations as $configuration) {
-            if (array_key_exists($configuration->getCountryCode(), $newMerchantIds)) {
+            if (\array_key_exists($configuration->getCountryCode(), $newMerchantIds)) {
                 $this->paymentMethodRepository->deletePaymentMethods($configuration->getMerchantId());
                 $configuration->setMerchantId($newMerchantIds[$configuration->getCountryCode()]);
             }

--- a/src/BusinessLogic/Domain/CountryConfiguration/Services/CountryConfigurationService.php
+++ b/src/BusinessLogic/Domain/CountryConfiguration/Services/CountryConfigurationService.php
@@ -53,7 +53,7 @@ class CountryConfigurationService
         }
 
         foreach ($configuredCountries as $key => $configuredCountry) {
-            if (!in_array($configuredCountry->getCountryCode(), $sellingCountries)) {
+            if (!\in_array($configuredCountry->getCountryCode(), $sellingCountries)) {
                 unset($configuredCountries[$key]);
             }
         }

--- a/src/BusinessLogic/Domain/Deployments/Services/DeploymentsService.php
+++ b/src/BusinessLogic/Domain/Deployments/Services/DeploymentsService.php
@@ -114,7 +114,7 @@ class DeploymentsService
         );
 
         return array_values(array_filter($deployments, function ($deployment) use ($connectedDeploymentIds) {
-            return !in_array($deployment->getId(), $connectedDeploymentIds);
+            return !\in_array($deployment->getId(), $connectedDeploymentIds);
         }));
     }
 }

--- a/src/BusinessLogic/Domain/Disconnect/Services/DisconnectService.php
+++ b/src/BusinessLogic/Domain/Disconnect/Services/DisconnectService.php
@@ -211,7 +211,7 @@ class DisconnectService
         $countryConfigurations = $this->countryConfigurationRepository->getCountryConfiguration();
         $newCountyConfigurations = [];
         foreach ($countryConfigurations as $countryConfiguration) {
-            if (!in_array($countryConfiguration->getMerchantId(), $merchantIds, true)) {
+            if (!\in_array($countryConfiguration->getMerchantId(), $merchantIds, true)) {
                 $newCountyConfigurations[] = $countryConfiguration;
             }
         }

--- a/src/BusinessLogic/Domain/GeneralSettings/Models/GeneralSettings.php
+++ b/src/BusinessLogic/Domain/GeneralSettings/Models/GeneralSettings.php
@@ -199,7 +199,7 @@ class GeneralSettings
     {
         $normalized = [];
         foreach ($countryCodes as $value) {
-            if (is_string($value) && !empty(trim($value))) {
+            if (\is_string($value) && !empty(trim($value))) {
                 $normalized[] = strtoupper(trim($value));
             }
         }

--- a/src/BusinessLogic/Domain/Multistore/StoreContext.php
+++ b/src/BusinessLogic/Domain/Multistore/StoreContext.php
@@ -57,7 +57,7 @@ class StoreContext
         try {
             self::getInstance()->storeId = $storeId;
 
-            $result = call_user_func_array($callback, $params);
+            $result = \call_user_func_array($callback, $params);
         } finally {
             self::getInstance()->storeId = $previousStoreId;
         }

--- a/src/BusinessLogic/Domain/Order/Models/OrderRequest/Gui.php
+++ b/src/BusinessLogic/Domain/Order/Models/OrderRequest/Gui.php
@@ -28,7 +28,7 @@ class Gui extends OrderRequestDTO
      */
     public function __construct(string $layout)
     {
-        if (!in_array($layout, self::ALLOWED_VALUES)) {
+        if (!\in_array($layout, self::ALLOWED_VALUES)) {
             throw new InvalidGuiLayoutValueException(
                 'Layout value must be one of the values defined in the allowed values constant.'
             );
@@ -49,7 +49,7 @@ class Gui extends OrderRequestDTO
     {
         $layout = self::getDataValue($data, 'layout', 'desktop');
 
-        if (!in_array($layout, self::ALLOWED_VALUES, true)) {
+        if (!\in_array($layout, self::ALLOWED_VALUES, true)) {
             throw new InvalidGuiLayoutValueException(
                 'Layout value must be one of the values defined in the allowed values constant.'
             );

--- a/src/BusinessLogic/Domain/Order/Models/OrderRequest/OrderRequestDTO.php
+++ b/src/BusinessLogic/Domain/Order/Models/OrderRequest/OrderRequestDTO.php
@@ -31,7 +31,7 @@ abstract class OrderRequestDTO extends DataTransferObject
                     lcfirst(preg_replace('/\d+/', '_$0', $propertyName))
                 ));
 
-                if (is_array($propertyValue)) {
+                if (\is_array($propertyValue)) {
                     $snakeCaseProperties = $this->handleArrayProperty(
                         $snakeCaseProperties,
                         $snakeCasePropertyName,
@@ -41,7 +41,7 @@ abstract class OrderRequestDTO extends DataTransferObject
                     continue;
                 }
 
-                is_object($propertyValue) && method_exists($propertyValue, 'toArray') ?
+                \is_object($propertyValue) && method_exists($propertyValue, 'toArray') ?
                     $snakeCaseProperties[$snakeCasePropertyName] = $propertyValue->toArray() :
                     $snakeCaseProperties[$snakeCasePropertyName] = $propertyValue;
             }
@@ -63,7 +63,7 @@ abstract class OrderRequestDTO extends DataTransferObject
     {
         $arrayData[$name] = [];
         foreach ($value as $key => $item) {
-            is_object($item) && method_exists($item, 'toArray') ?
+            \is_object($item) && method_exists($item, 'toArray') ?
                 $arrayData[$name][] = $item->toArray() :
                 $arrayData[$name][$key] = $item;
         }

--- a/src/BusinessLogic/Domain/Order/OrderRequestStatusMapping.php
+++ b/src/BusinessLogic/Domain/Order/OrderRequestStatusMapping.php
@@ -34,7 +34,7 @@ class OrderRequestStatusMapping
      */
     public static function mapOrderRequestStatus(string $status): string
     {
-        if (!array_key_exists($status, self::$statusMap)) {
+        if (!\array_key_exists($status, self::$statusMap)) {
             throw new InvalidOrderStateException("Invalid order state '{$status}'", 400);
         }
 

--- a/src/BusinessLogic/Domain/Order/Service/OrderService.php
+++ b/src/BusinessLogic/Domain/Order/Service/OrderService.php
@@ -359,7 +359,7 @@ class OrderService
         } catch (HttpApiNotFoundException $exception) {
             // Ignore not found errors for cancellation actions because SeQura returns
             // not found response for on-hold to cancel transitions (immediate cancelations from checkout)
-            if (!in_array($order->getState(), [OrderRequestStates::CANCELLED, OrderRequestStates::ON_HOLD])) {
+            if (!\in_array($order->getState(), [OrderRequestStates::CANCELLED, OrderRequestStates::ON_HOLD])) {
                 throw $exception;
             }
         }
@@ -473,7 +473,7 @@ class OrderService
         foreach ($methodCategories as $category) {
             foreach ($category->getMethods() as $method) {
                 if ($method->getProduct() === $paymentMethodId) {
-                    $name = in_array($paymentMethodId, self::INSTALLMENT_METHOD_CODES) ?
+                    $name = \in_array($paymentMethodId, self::INSTALLMENT_METHOD_CODES) ?
                         $category->getTitle() :
                         $method->getTitle();
                     $icon = $method->getIcon() ?? '';

--- a/src/BusinessLogic/Domain/OrderReport/Models/OrderReport.php
+++ b/src/BusinessLogic/Domain/OrderReport/Models/OrderReport.php
@@ -100,7 +100,7 @@ class OrderReport extends OrderRequestDTO
         ?Address $deliveryAddress = null,
         ?Address $invoiceAddress = null
     ) {
-        if (!in_array($state, OrderDeliveryStates::toArray(), true)) {
+        if (!\in_array($state, OrderDeliveryStates::toArray(), true)) {
             throw new InvalidOrderDeliveryStateException('Invalid order delivery state: ' . $state);
         }
 

--- a/src/BusinessLogic/Domain/OrderReport/OrderReporter.php
+++ b/src/BusinessLogic/Domain/OrderReport/OrderReporter.php
@@ -56,7 +56,7 @@ class OrderReporter extends Orchestrator
     public static function fromArray(array $array): Serializable
     {
         $entity = parent::fromArray($array);
-        $entity->page = intval($array['page']);
+        $entity->page = \intval($array['page']);
         $entity->storeId = (string) $array['storeId'];
 
         return $entity;

--- a/src/BusinessLogic/Domain/OrderStatusSettings/Models/OrderStatusMapping.php
+++ b/src/BusinessLogic/Domain/OrderStatusSettings/Models/OrderStatusMapping.php
@@ -39,7 +39,7 @@ class OrderStatusMapping
             );
         }
 
-        if (!in_array($seQuraStatus, OrderStates::toArray(), true)) {
+        if (!\in_array($seQuraStatus, OrderStates::toArray(), true)) {
             throw new InvalidSeQuraOrderStatusException(
                 new TranslatableLabel('Invalid SeQura order status.', 'general.errors.orderStatusMapping.invalidStatus')
             );

--- a/src/BusinessLogic/Domain/OrderStatusSettings/Services/OrderStatusSettingsService.php
+++ b/src/BusinessLogic/Domain/OrderStatusSettings/Services/OrderStatusSettingsService.php
@@ -64,7 +64,7 @@ class OrderStatusSettingsService implements OrderStatusProvider
         }, $this->integrationShopOrderStatusesService->getShopOrderStatuses());
 
         foreach ($orderStatusMappings as $mapping) {
-            if (!in_array($mapping->getShopStatus(), $shopStatusIds, true)) {
+            if (!\in_array($mapping->getShopStatus(), $shopStatusIds, true)) {
                 $mapping->setShopStatus('');
             }
         }

--- a/src/BusinessLogic/Domain/PaymentMethod/Models/SeQuraPaymentMethod.php
+++ b/src/BusinessLogic/Domain/PaymentMethod/Models/SeQuraPaymentMethod.php
@@ -437,7 +437,7 @@ class SeQuraPaymentMethod
      */
     public function shouldShowMoreInfo(): bool
     {
-        return !in_array($this->product, self::NOT_ALLOWED_MORE_PRODUCT_INFO, true);
+        return !\in_array($this->product, self::NOT_ALLOWED_MORE_PRODUCT_INFO, true);
     }
 
     /**
@@ -471,7 +471,7 @@ class SeQuraPaymentMethod
 
         $data = json_decode($data, true);
 
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             return null;
         }
         return self::fromArray($data);

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetSettingsService.php
@@ -346,7 +346,7 @@ class WidgetSettingsService
         );
 
         return array_filter($paymentMethods, static function ($method) {
-            return in_array($method->getCategory(), self::WIDGET_SUPPORTED_CATEGORIES_ON_PRODUCT_PAGE);
+            return \in_array($method->getCategory(), self::WIDGET_SUPPORTED_CATEGORIES_ON_PRODUCT_PAGE);
         });
     }
 
@@ -380,7 +380,7 @@ class WidgetSettingsService
         foreach ($paymentMethods as $method) {
             if (
                 $method->getProduct() === $selectedProduct &&
-                in_array($method->getCategory(), $categories, true)
+                \in_array($method->getCategory(), $categories, true)
             ) {
                 return $method;
             }
@@ -433,7 +433,7 @@ class WidgetSettingsService
         $widgetSupportedProducts = [];
 
         foreach ($paymentMethods as $paymentMethod) {
-            if (in_array($paymentMethod->getCategory(), $supportedCategories, true)) {
+            if (\in_array($paymentMethod->getCategory(), $supportedCategories, true)) {
                 $widgetSupportedProducts [] = $paymentMethod->getProduct();
             }
         }

--- a/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetValidationService.php
+++ b/src/BusinessLogic/Domain/PromotionalWidgets/Services/WidgetValidationService.php
@@ -61,7 +61,7 @@ class WidgetValidationService
 
         $allowedIPAddresses = $generalSettings->getAllowedIPAddresses() ?? [];
 
-        return !(!empty($allowedIPAddresses) && !in_array($currentIpAddress, $allowedIPAddresses, true));
+        return !(!empty($allowedIPAddresses) && !\in_array($currentIpAddress, $allowedIPAddresses, true));
     }
 
     /**
@@ -73,7 +73,7 @@ class WidgetValidationService
      */
     public function isCurrencySupported(string $currentCurrency): bool
     {
-        return in_array($currentCurrency, self::SUPPORTED_CURRENCIES, true);
+        return \in_array($currentCurrency, self::SUPPORTED_CURRENCIES, true);
     }
 
     /**
@@ -107,7 +107,7 @@ class WidgetValidationService
 
             if (
                 $excludedProducts &&
-                in_array($productSku, $excludedProducts, true)
+                \in_array($productSku, $excludedProducts, true)
             ) {
                 return false;
             }

--- a/src/BusinessLogic/Domain/StoreIntegration/Models/CreateStoreIntegrationResponse.php
+++ b/src/BusinessLogic/Domain/StoreIntegration/Models/CreateStoreIntegrationResponse.php
@@ -49,7 +49,7 @@ class CreateStoreIntegrationResponse
 
         $path = parse_url($locationHeader, PHP_URL_PATH);
 
-        if (is_string($path) && preg_match('#store_integrations/(\d+)#', $path, $matches)) {
+        if (\is_string($path) && preg_match('#store_integrations/(\d+)#', $path, $matches)) {
             return new self($matches[1]);
         }
 

--- a/src/BusinessLogic/Domain/StoreIntegration/Models/CreateStoreIntegrationResponse.php
+++ b/src/BusinessLogic/Domain/StoreIntegration/Models/CreateStoreIntegrationResponse.php
@@ -49,7 +49,7 @@ class CreateStoreIntegrationResponse
 
         $path = parse_url($locationHeader, PHP_URL_PATH);
 
-        if (preg_match('#store_integrations/(\d+)#', $path, $matches)) {
+        if (is_string($path) && preg_match('#store_integrations/(\d+)#', $path, $matches)) {
             return new self($matches[1]);
         }
 

--- a/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/Authorization/AuthorizedProxy.php
@@ -68,7 +68,7 @@ class AuthorizedProxy extends BaseProxy
      */
     protected function getHeaders(): array
     {
-        $token = base64_encode(sprintf(
+        $token = base64_encode(\sprintf(
             '%s:%s',
             $this->connectionData->getAuthorizationCredentials()->getUsername(),
             $this->connectionData->getAuthorizationCredentials()->getPassword()

--- a/src/BusinessLogic/SeQuraAPI/BaseProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/BaseProxy.php
@@ -73,7 +73,7 @@ class BaseProxy
     public static function getSandboxApiBaseUrlOverride(): ?string
     {
         $apiBaseUrl = getenv(self::SANDBOX_API_BASE_URL_ENV);
-        if (!is_string($apiBaseUrl)) {
+        if (!\is_string($apiBaseUrl)) {
             return null;
         }
 
@@ -221,7 +221,7 @@ class BaseProxy
         $sanitizedEndpoint = ltrim($request->getEndpoint(), '/');
         $queryString = $this->getQueryString($request);
 
-        return sprintf('%s%s%s', $this->baseUrl, $sanitizedEndpoint, !empty($queryString) ? "?$queryString" : '');
+        return \sprintf('%s%s%s', $this->baseUrl, $sanitizedEndpoint, !empty($queryString) ? "?$queryString" : '');
     }
 
     /**

--- a/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
+++ b/src/BusinessLogic/SeQuraAPI/Connection/Request/ValidateConnectionHttpRequest.php
@@ -36,7 +36,7 @@ class ValidateConnectionHttpRequest extends HttpRequest
      */
     protected function generateAuthHeaderForValidation(AuthorizationCredentials $authorizationCredentials): array
     {
-        $token = base64_encode(sprintf(
+        $token = base64_encode(\sprintf(
             '%s:%s',
             $authorizationCredentials->getUsername(),
             $authorizationCredentials->getPassword()

--- a/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
+++ b/src/BusinessLogic/SeQuraAPI/Exceptions/HttpApiRequestException.php
@@ -61,13 +61,13 @@ class HttpApiRequestException extends HttpRequestException
         if (json_last_error() !== JSON_ERROR_NONE) {
             return $errors; // Return empty array if JSON decoding fails
         }
-        if (!is_array($responseBody) || !isset($responseBody['errors'])) {
+        if (!\is_array($responseBody) || !isset($responseBody['errors'])) {
             return $errors;
         }
         foreach ($responseBody['errors'] as $error) {
-            if (is_string($error)) {
+            if (\is_string($error)) {
                 $errors[] = $error;
-            } elseif (is_array($error) && isset($error['title'])) {
+            } elseif (\is_array($error) && isset($error['title'])) {
                 $errors[] = $error['title'];
             }
         }

--- a/src/BusinessLogic/SeQuraAPI/Order/OrderProxy.php
+++ b/src/BusinessLogic/SeQuraAPI/Order/OrderProxy.php
@@ -158,7 +158,7 @@ class OrderProxy implements OrderProxyInterface
     protected function getOrderUUID(array $headers): string
     {
         $headers = array_change_key_case($headers);
-        $location = array_key_exists('location', $headers) ? $headers['location'] : '';
+        $location = \array_key_exists('location', $headers) ? $headers['location'] : '';
 
         return !empty($location) ? basename(parse_url($location, PHP_URL_PATH)) : '';
     }

--- a/src/BusinessLogic/Utility/StringValidator.php
+++ b/src/BusinessLogic/Utility/StringValidator.php
@@ -58,7 +58,7 @@ class StringValidator
      */
     public static function isStringLengthBetween(string $string, int $minLength, int $maxLength): bool
     {
-        return strlen($string) >= $minLength && strlen($string) <= $maxLength;
+        return \strlen($string) >= $minLength && \strlen($string) <= $maxLength;
     }
 
     /**

--- a/src/BusinessLogic/Webhook/Handler/WebhookHandler.php
+++ b/src/BusinessLogic/Webhook/Handler/WebhookHandler.php
@@ -78,7 +78,7 @@ class WebhookHandler
         $task = new OrderUpdateTask($webhook);
         $task->execute();
 
-        if (in_array($webhook->getSqState(), [OrderStates::STATE_APPROVED, OrderStates::STATE_NEEDS_REVIEW], true)) {
+        if (\in_array($webhook->getSqState(), [OrderStates::STATE_APPROVED, OrderStates::STATE_NEEDS_REVIEW], true)) {
             $this->acknowledgeOrder($webhook->getOrderRef(), $webhook->getSqState());
         }
     }

--- a/src/BusinessLogic/Webhook/Validator/WebhookValidator.php
+++ b/src/BusinessLogic/Webhook/Validator/WebhookValidator.php
@@ -48,7 +48,7 @@ class WebhookValidator
             throw new InvalidSignatureException('Signature mismatch.', 400);
         }
 
-        if (!in_array($webhook->sqState, self::ALLOWED_STATES)) {
+        if (!\in_array($webhook->sqState, self::ALLOWED_STATES)) {
             throw new InvalidStateException("Unknown event '{$webhook->sqState}'", 400);
         }
     }

--- a/src/Infrastructure/AutoTest/AutoTestService.php
+++ b/src/Infrastructure/AutoTest/AutoTestService.php
@@ -121,7 +121,7 @@ class AutoTestService
 
         return new AutoTestStatus(
             $status,
-            in_array($status, array('timeout', QueueItem::COMPLETED, QueueItem::FAILED), true),
+            \in_array($status, array('timeout', QueueItem::COMPLETED, QueueItem::FAILED), true),
             $status === 'timeout' ? 'Task could not be started.' : '',
             AutoTestLogger::getInstance()->getLogs()
         );

--- a/src/Infrastructure/Configuration/Configuration.php
+++ b/src/Infrastructure/Configuration/Configuration.php
@@ -522,7 +522,7 @@ abstract class Configuration extends Singleton
      */
     protected function isContextSpecific($name)
     {
-        return !in_array($name, static::$globalConfigValues, true);
+        return !\in_array($name, static::$globalConfigValues, true);
     }
 
     /**

--- a/src/Infrastructure/Data/Transformer.php
+++ b/src/Infrastructure/Data/Transformer.php
@@ -32,7 +32,7 @@ class Transformer
     {
         $result = array();
 
-        if (!is_array($batch)) {
+        if (!\is_array($batch)) {
             return $result;
         }
 
@@ -51,11 +51,11 @@ class Transformer
     protected static function trim(array &$data): void
     {
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 static::trim($data[$key]);
             }
 
-            if ($value === null || (is_array($value) && empty($value))) {
+            if ($value === null || (\is_array($value) && empty($value))) {
                 unset($data[$key]);
             }
         }

--- a/src/Infrastructure/Http/AsyncSocketHttpClient.php
+++ b/src/Infrastructure/Http/AsyncSocketHttpClient.php
@@ -144,7 +144,7 @@ class AsyncSocketHttpClient extends CurlHttpClient
             $payload .= $header . (!empty($value) ? ": $value" : '') . "\r\n";
         }
 
-        $payload .= "Content-Length: " . strlen($body) . "\r\n";
+        $payload .= "Content-Length: " . \strlen($body) . "\r\n";
         $payload .= "Connection: close\r\n\r\n";
 
         $payload .= $body . "\r\n\r\n";

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -137,7 +137,7 @@ class CurlHttpClient extends HttpClient
 
         // 0 status code is set when timeout is reached
         if (
-            !in_array($statusCode, array(0, 200), true)
+            !\in_array($statusCode, array(0, 200), true)
             && curl_errno($this->curlSession) !== CURLE_OPERATION_TIMEOUTED
         ) {
             $curlError = '';
@@ -182,7 +182,7 @@ class CurlHttpClient extends HttpClient
     protected function initializeCurlSession(): void
     {
         // this constant is not defined prior to php 7.0.7
-        if (!defined('CURL_REDIR_POST_ALL')) {
+        if (!\defined('CURL_REDIR_POST_ALL')) {
             define('CURL_REDIR_POST_ALL', 7);
         }
 
@@ -223,7 +223,7 @@ class CurlHttpClient extends HttpClient
         $this->curlOptions[CURLOPT_HTTPHEADER] = $headers;
 
         $methodsWithBody = array(static::HTTP_METHOD_POST, static::HTTP_METHOD_PUT, static::HTTP_METHOD_PATCH);
-        if (in_array($method, $methodsWithBody, true)) {
+        if (\in_array($method, $methodsWithBody, true)) {
             $this->curlOptions[CURLOPT_POSTFIELDS] = $body;
         }
     }
@@ -321,12 +321,12 @@ class CurlHttpClient extends HttpClient
             static function ($curl, $header) use (&$headers) {
                 // Set only valid headers
                 $headerArray = explode(':', $header, 2);
-                if (count($headerArray) >= 2) {
+                if (\count($headerArray) >= 2) {
                     $headers[trim($headerArray[0])] = trim($headerArray[1]);
                 }
 
                 // Do not use mb_strlen here because curl expects number of bytes to be returned not number of chars
-                return strlen($header);
+                return \strlen($header);
             }
         );
 

--- a/src/Infrastructure/Logger/LogData.php
+++ b/src/Infrastructure/Logger/LogData.php
@@ -218,7 +218,7 @@ class LogData extends Entity
     {
         $dateTime = TimeProvider::getInstance()->getDateTime((int)($this->getTimestamp() / 1000));
 
-        return sprintf(
+        return \sprintf(
             "%s\t%s\t%s\t%s\r\n",
             $this->getLevelName(),
             TimeProvider::getInstance()->serializeDate($dateTime, 'Y-m-d H:i:s'),
@@ -239,7 +239,7 @@ class LogData extends Entity
         $ctx = [];
         foreach ($this->getContext() as $logContextData) {
             $arr = $logContextData->toArray();
-            if (isset($arr['value']) && is_string($arr['value'])) {
+            if (isset($arr['value']) && \is_string($arr['value'])) {
                 $decoded = json_decode($arr['value'], true);
                 if ($decoded !== null) {
                     $arr['value'] = $decoded;

--- a/src/Infrastructure/ORM/Configuration/Index.php
+++ b/src/Infrastructure/ORM/Configuration/Index.php
@@ -52,7 +52,7 @@ class Index
      */
     public function __construct($type, $property)
     {
-        if (!in_array($type, array(self::BOOLEAN, self::DATETIME, self::DOUBLE, self::INTEGER, self::STRING), true)) {
+        if (!\in_array($type, array(self::BOOLEAN, self::DATETIME, self::DOUBLE, self::INTEGER, self::STRING), true)) {
             throw new InvalidArgumentException("Invalid index type given: $type.");
         }
 

--- a/src/Infrastructure/ORM/Entity.php
+++ b/src/Infrastructure/ORM/Entity.php
@@ -153,6 +153,6 @@ abstract class Entity extends DataTransferObject
      */
     protected static function getArrayValue($search, $key, $default = null)
     {
-        return array_key_exists($key, $search) ? $search[$key] : $default;
+        return \array_key_exists($key, $search) ? $search[$key] : $default;
     }
 }

--- a/src/Infrastructure/ORM/IntermediateObject.php
+++ b/src/Infrastructure/ORM/IntermediateObject.php
@@ -162,7 +162,7 @@ class IntermediateObject
      */
     public function setIndexValue($index, $value): void
     {
-        if (!is_int($index) || $index < 1 || !is_string($value)) {
+        if (!\is_int($index) || $index < 1 || !\is_string($value)) {
             return;
         }
 
@@ -184,14 +184,14 @@ class IntermediateObject
     public function getIndexValue($index): ?string
     {
         $value = null;
-        if (!is_int($index) || $index < 1) {
+        if (!\is_int($index) || $index < 1) {
             return $value;
         }
 
         if ($index <= 6) {
             $methodName = 'getIndex' . $index;
             $value = $this->$methodName();
-        } elseif (array_key_exists('index_' . $index, $this->otherIndexes)) {
+        } elseif (\array_key_exists('index_' . $index, $this->otherIndexes)) {
             $value = $this->otherIndexes['index_' . $index];
         }
 

--- a/src/Infrastructure/ORM/QueryFilter/QueryCondition.php
+++ b/src/Infrastructure/ORM/QueryFilter/QueryCondition.php
@@ -47,7 +47,7 @@ class QueryCondition
         $this->operator = $operator;
         $this->value = $value;
 
-        $this->valueType = gettype($value);
+        $this->valueType = \gettype($value);
         if ($this->valueType === 'object' && $value instanceof DateTime) {
             $this->valueType = 'dateTime';
         }

--- a/src/Infrastructure/ORM/QueryFilter/QueryFilter.php
+++ b/src/Infrastructure/ORM/QueryFilter/QueryFilter.php
@@ -5,8 +5,6 @@ namespace SeQura\Core\Infrastructure\ORM\QueryFilter;
 use SeQura\Core\Infrastructure\ORM\Exceptions\QueryFilterInvalidParamException;
 use DateTime;
 
-use function in_array;
-
 /**
  * Class QueryFilter.
  *
@@ -107,7 +105,7 @@ class QueryFilter
      */
     public function orderBy($column, string $direction = self::ORDER_ASC): QueryFilter
     {
-        if (!is_string($column) || !in_array($direction, array(self::ORDER_ASC, self::ORDER_DESC), false)) {
+        if (!\is_string($column) || !\in_array($direction, array(self::ORDER_ASC, self::ORDER_DESC), false)) {
             throw new QueryFilterInvalidParamException(
                 'Column value must be string type and direction must be ASC or DESC'
             );
@@ -200,25 +198,25 @@ class QueryFilter
      */
     protected function validateConditionParameters($column, $operator, $value): void
     {
-        if (!is_string($column) || !is_string($operator)) {
+        if (!\is_string($column) || !\is_string($operator)) {
             throw new QueryFilterInvalidParamException('Column and operator values must be string types');
         }
 
         $operator = strtoupper($operator);
-        if (!in_array($operator, Operators::$AVAILABLE_OPERATORS, true)) {
+        if (!\in_array($operator, Operators::$AVAILABLE_OPERATORS, true)) {
             throw new QueryFilterInvalidParamException("Operator $operator is not supported");
         }
 
-        $valueType = gettype($value);
+        $valueType = \gettype($value);
         if ($valueType === 'object' && $value instanceof DateTime) {
             $valueType = 'dateTime';
         }
 
-        if (!array_key_exists($valueType, Operators::$TYPE_OPERATORS)) {
+        if (!\array_key_exists($valueType, Operators::$TYPE_OPERATORS)) {
             throw new QueryFilterInvalidParamException('Value type is not supported');
         }
 
-        if (!in_array($operator, Operators::$TYPE_OPERATORS[$valueType], true)) {
+        if (!\in_array($operator, Operators::$TYPE_OPERATORS[$valueType], true)) {
             throw new QueryFilterInvalidParamException("Operator $operator is not supported for $valueType type");
         }
     }

--- a/src/Infrastructure/ORM/RepositoryRegistry.php
+++ b/src/Infrastructure/ORM/RepositoryRegistry.php
@@ -39,7 +39,7 @@ class RepositoryRegistry
             throw new RepositoryNotRegisteredException("Repository for entity $entityClass not found or registered.");
         }
 
-        if (!array_key_exists($entityClass, static::$instantiated)) {
+        if (!\array_key_exists($entityClass, static::$instantiated)) {
             $repositoryClass = static::$repositories[$entityClass];
             /**
              * @var RepositoryInterface $repository

--- a/src/Infrastructure/ORM/Utility/IndexHelper.php
+++ b/src/Infrastructure/ORM/Utility/IndexHelper.php
@@ -61,7 +61,7 @@ class IndexHelper
      */
     public static function castFieldValue($value, string $type)
     {
-        if ($value === null || is_string($value)) {
+        if ($value === null || \is_string($value)) {
             return $value;
         }
 
@@ -69,20 +69,20 @@ class IndexHelper
             return (string)$value->getTimestamp();
         }
 
-        if ($type === 'integer' && is_int($value)) {
-            return sprintf('%011d', $value);
+        if ($type === 'integer' && \is_int($value)) {
+            return \sprintf('%011d', $value);
         }
 
-        if ($type === 'double' && is_float($value)) {
+        if ($type === 'double' && \is_float($value)) {
             // 123.15 => 00000000123.15000, padding to 11 numbers before and padding to 5 behind decimal point
-            return sprintf('%017.5f', $value);
+            return \sprintf('%017.5f', $value);
         }
 
-        if ($type === 'boolean' && is_bool($value)) {
+        if ($type === 'boolean' && \is_bool($value)) {
             return $value ? '1' : '0';
         }
 
-        if ($type === 'array' && is_array($value)) {
+        if ($type === 'array' && \is_array($value)) {
             return array_values($value);
         }
 

--- a/src/Infrastructure/Serializer/Concrete/JsonSerializer.php
+++ b/src/Infrastructure/Serializer/Concrete/JsonSerializer.php
@@ -21,15 +21,15 @@ class JsonSerializer extends Serializer
      */
     protected function doSerialize($data)
     {
-        if (is_object($data) && method_exists($data, 'toArray')) {
+        if (\is_object($data) && method_exists($data, 'toArray')) {
             $preparedArray = $data->toArray();
-            $preparedArray['class_name'] = get_class($data);
+            $preparedArray['class_name'] = \get_class($data);
 
             return json_encode($preparedArray);
         }
 
         if ($data instanceof stdClass) {
-            $data->className = get_class($data);
+            $data->className = \get_class($data);
         }
 
         return json_encode($data);
@@ -46,7 +46,7 @@ class JsonSerializer extends Serializer
     {
         $unserialized = json_decode($serialized, true);
 
-        if (!is_array($unserialized) || !array_key_exists('class_name', $unserialized)) {
+        if (!\is_array($unserialized) || !\array_key_exists('class_name', $unserialized)) {
             return $unserialized;
         }
 

--- a/src/Infrastructure/ServiceRegister.php
+++ b/src/Infrastructure/ServiceRegister.php
@@ -97,7 +97,7 @@ class ServiceRegister
      */
     protected function register(string $type, callable $delegate): void
     {
-        if (!is_callable($delegate)) {
+        if (!\is_callable($delegate)) {
             throw new InvalidArgumentException("$type delegate is not callable.");
         }
 
@@ -119,6 +119,6 @@ class ServiceRegister
             throw new ServiceNotRegisteredException($type);
         }
 
-        return call_user_func($this->services[$type]);
+        return \call_user_func($this->services[$type]);
     }
 }

--- a/src/Infrastructure/TaskExecution/AsyncBatchStarter.php
+++ b/src/Infrastructure/TaskExecution/AsyncBatchStarter.php
@@ -231,7 +231,7 @@ class AsyncBatchStarter implements Runnable
         }
 
         $subBatchWaitTime = $this->batchSize * $this->getMaxNestingLevels() * $requestDuration;
-        $runnersStartupTime = count($this->runners) * $requestDuration;
+        $runnersStartupTime = \count($this->runners) * $requestDuration;
 
         return $subBatchWaitTime - $runnersStartupTime;
     }
@@ -242,7 +242,7 @@ class AsyncBatchStarter implements Runnable
     public function __toString()
     {
         $out = implode(', ', $this->subBatches);
-        $countOfRunners = count($this->runners);
+        $countOfRunners = \count($this->runners);
         for ($i = 0; $i < $countOfRunners; $i++) {
             $out .= empty($out) ? 'R' : ', R';
         }
@@ -265,7 +265,7 @@ class AsyncBatchStarter implements Runnable
      */
     protected function isSubBatchCapacityFull(): bool
     {
-        return count($this->subBatches) >= $this->batchSize;
+        return \count($this->subBatches) >= $this->batchSize;
     }
 
     /**
@@ -274,7 +274,7 @@ class AsyncBatchStarter implements Runnable
      */
     protected function isRunnersCapacityFull(): bool
     {
-        return count($this->runners) >= $this->batchSize;
+        return \count($this->runners) >= $this->batchSize;
     }
 
     /**

--- a/src/Infrastructure/TaskExecution/QueueItem.php
+++ b/src/Infrastructure/TaskExecution/QueueItem.php
@@ -292,7 +292,7 @@ class QueueItem extends Entity
     public function setStatus(string $status): void
     {
         if (
-            !in_array(
+            !\in_array(
                 $status,
                 array(
                     self::CREATED,
@@ -306,7 +306,7 @@ class QueueItem extends Entity
             )
         ) {
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     'Invalid QueueItem status: "%s". '
                     . 'Status must be one of "%s", "%s", "%s", "%s", "%s" or "%s" values.',
                     $status,
@@ -367,7 +367,7 @@ class QueueItem extends Entity
     public function setLastExecutionProgressBasePoints(int $lastExecutionProgressBasePoints): void
     {
         if (
-            !is_int($lastExecutionProgressBasePoints) ||
+            !\is_int($lastExecutionProgressBasePoints) ||
             $lastExecutionProgressBasePoints < 0 ||
             10000 < $lastExecutionProgressBasePoints
         ) {
@@ -410,7 +410,7 @@ class QueueItem extends Entity
      */
     public function setProgressBasePoints($progressBasePoints): void
     {
-        if (!is_int($progressBasePoints) || $progressBasePoints < 0 || 10000 < $progressBasePoints) {
+        if (!\is_int($progressBasePoints) || $progressBasePoints < 0 || 10000 < $progressBasePoints) {
             throw new InvalidArgumentException('Progress percentage must be value between 0 and 100.');
         }
 
@@ -746,7 +746,7 @@ class QueueItem extends Entity
      */
     public function setPriority(int $priority): void
     {
-        if (!in_array($priority, static::getAvailablePriorities(), true)) {
+        if (!\in_array($priority, static::getAvailablePriorities(), true)) {
             throw new InvalidArgumentException("Priority {$priority} is not supported.");
         }
 

--- a/src/Infrastructure/TaskExecution/QueueService.php
+++ b/src/Infrastructure/TaskExecution/QueueService.php
@@ -322,7 +322,7 @@ class QueueService
      */
     public function abort(QueueItem $queueItem, string $abortDescription): void
     {
-        if (!in_array($queueItem->getStatus(), [QueueItem::CREATED, QueueItem::QUEUED, QueueItem::IN_PROGRESS])) {
+        if (!\in_array($queueItem->getStatus(), [QueueItem::CREATED, QueueItem::QUEUED, QueueItem::IN_PROGRESS])) {
             $this->throwIllegalTransitionException($queueItem->getStatus(), QueueItem::ABORTED);
         }
 
@@ -507,14 +507,14 @@ class QueueService
             $batch = $this->getStorage()->findOldestQueuedItems($priority, $currentLimit);
             $result[] = $batch;
 
-            if (($currentLimit -= count($batch)) <= 0) {
+            if (($currentLimit -= \count($batch)) <= 0) {
                 break;
             }
         }
 
         $result = !empty($result) ? array_merge(...$result) : $result;
 
-        return array_slice($result, 0, $limit);
+        return \array_slice($result, 0, $limit);
     }
 
     /**
@@ -665,7 +665,7 @@ class QueueService
     protected function throwIllegalTransitionException(string $fromStatus, string $toStatus): void
     {
         throw new BadMethodCallException(
-            sprintf(
+            \sprintf(
                 'Illegal queue item state transition from "%s" to "%s"',
                 $fromStatus,
                 $toStatus

--- a/src/Infrastructure/TaskExecution/Task.php
+++ b/src/Infrastructure/TaskExecution/Task.php
@@ -120,7 +120,7 @@ abstract class Task extends EventEmitter implements Serializable
      */
     public function reportProgress($progressPercent): void
     {
-        if (!is_int($progressPercent) && !is_float($progressPercent)) {
+        if (!\is_int($progressPercent) && !\is_float($progressPercent)) {
             throw new InvalidArgumentException('Progress percentage must be value integer or float value');
         }
 
@@ -186,11 +186,11 @@ abstract class Task extends EventEmitter implements Serializable
      */
     public static function getClassName(): string
     {
-        $namespaceParts = explode('\\', get_called_class());
+        $namespaceParts = explode('\\', \get_called_class());
         $name = end($namespaceParts);
 
         if ($name === 'Task') {
-            throw new RuntimeException('Constant CLASS_NAME not defined in class ' . get_called_class());
+            throw new RuntimeException('Constant CLASS_NAME not defined in class ' . \get_called_class());
         }
 
         return $name;

--- a/src/Infrastructure/TaskExecution/TaskEvents/TaskProgressEvent.php
+++ b/src/Infrastructure/TaskExecution/TaskEvents/TaskProgressEvent.php
@@ -35,7 +35,7 @@ class TaskProgressEvent extends Event
     public function __construct($progressPercentBasePoints)
     {
         if (
-            !is_int($progressPercentBasePoints)
+            !\is_int($progressPercentBasePoints)
             || $progressPercentBasePoints < 0
             || 10000 < $progressPercentBasePoints
         ) {

--- a/src/Infrastructure/TaskExecution/TaskRunner.php
+++ b/src/Infrastructure/TaskExecution/TaskRunner.php
@@ -165,7 +165,7 @@ class TaskRunner
                 // If task can't be deserialized we should fail it immediately since there is nothing we can dao to recover
                 $this->getQueue()->fail(
                     $runningItem,
-                    sprintf(
+                    \sprintf(
                         'Task %s is invalid or corrupted. Task deserialization failed.',
                         $runningItem->getId()
                     ),
@@ -200,7 +200,7 @@ class TaskRunner
             $item->reconfigureTask();
             $this->getQueue()->fail(
                 $item,
-                sprintf(
+                \sprintf(
                     'Task %s failed due to extended inactivity period.',
                     $this->getItemDescription($item)
                 )
@@ -227,7 +227,7 @@ class TaskRunner
         // Calculate how many queue items can be started
         $maxRunningTasks = $this->getConfigurationService()->getMaxStartedTasksLimit();
         $alreadyRunningItems = $this->getQueue()->findRunningItems();
-        $numberOfAvailableSlots = $maxRunningTasks - count($alreadyRunningItems);
+        $numberOfAvailableSlots = $maxRunningTasks - \count($alreadyRunningItems);
         if ($numberOfAvailableSlots <= 0) {
             $this->logDebug(array('Message' => 'Task runner: max number of active tasks reached.'));
 
@@ -272,7 +272,7 @@ class TaskRunner
                 'Message' => 'Task runner: Batch starter execution finished.',
                 'ExecutionTime' => ($endTime - $startTime) . 's',
                 'AverageRequestTime' => $averageRequestTime . 's',
-                'StartedItems' => count($items),
+                'StartedItems' => \count($items),
             )
         );
     }

--- a/src/Infrastructure/Utility/Events/EventEmitter.php
+++ b/src/Infrastructure/Utility/Events/EventEmitter.php
@@ -36,10 +36,10 @@ abstract class EventEmitter
      */
     protected function fire(Event $event): void
     {
-        $eventClass = get_class($event);
+        $eventClass = \get_class($event);
         if (!empty($this->handlers[$eventClass])) {
             foreach ($this->handlers[$eventClass] as $handler) {
-                call_user_func($handler, $event);
+                \call_user_func($handler, $event);
             }
         }
     }

--- a/src/Infrastructure/Utility/Php.php
+++ b/src/Infrastructure/Utility/Php.php
@@ -11,8 +11,8 @@ class Php
      */
     public static function classUsesRecursive($class): array
     {
-        if (is_object($class)) {
-            $class = get_class($class);
+        if (\is_object($class)) {
+            $class = \get_class($class);
         }
 
         $results = [];


### PR DESCRIPTION
### What is the goal?

Verify the project runs on PHP 8.5, harden the codebase against PHP 8.5-leaning deprecations without dropping PHP 7.2 minimum support, and enforce the opcache-call-site-specialization convention going forward.

### References
* **Issue:** [PAR-789](https://sequra.atlassian.net/browse/PAR-789)

### How is it being implemented?

- Pin `phpcompatibility/php-compatibility` to `^9.3` (Step 1).
- Add a PHP 8.5 syntax-check row to `.github/workflows/pipeline.yml` (Step 2).
- Verify PHP 8.5 `php -l` passes across `src/` and that PHPCS `testVersion=7.2-` is clean (Steps 3–4).
- Audit dynamic property writes (none confirmed) and `gettype()` consumers (consistent legacy spellings) (Steps 5–6).
- Guard `preg_match` against a null `parse_url` return in `CreateStoreIntegrationResponse::fromLocationHeader` (Step 7).
- Verify the full test suite (757 tests, 2326 assertions) passes on PHP 8.5 with deprecation reporting suppressed; PHPUnit 8.5.14 itself emits internal deprecations on PHP 8.5 — recorded as a follow-up, out of scope (Step 8).
- Prefix every callsite of the opcache-specialized function set (`is_*`, `in_array`, `count`, `sprintf`, `strlen`, `gettype`, `get_class`, etc.) with `\` across `src/` — 117 callsites in 56 files (Step 10).
- Enforce the prefix going forward via slevomat/coding-standard's `FullyQualifiedGlobalFunctions` sniff with `includeSpecialFunctions=true` (Step 11).

### Opportunistic refactorings

- Hardened `CreateStoreIntegrationResponse::fromLocationHeader` so a `Location` header without a path component no longer triggers a PHP 8.1+ deprecation via `preg_match` with a non-string subject.
- Dropped the now-redundant `use function in_array;` import in `QueryFilter.php`.

### Caveats

- PHPUnit stays pinned at 8.5.14 per scope decision. Running 8.5.14 against PHP 8.5 emits deprecation warnings from PHPUnit's own `ErrorHandler.php` (references the removed `E_STRICT` constant) and from `ExceptionWrapper` (implicit nullable parameter). Tests themselves still pass when `error_reporting` excludes deprecation levels. A PHPUnit version bump is a separate follow-up.
- Out-of-scope `parse_url(..., PHP_URL_HOST)` callsites in `OrderProxy`, `HttpClient`, `CurlHttpClient`, and `AutoTestService` can TypeError on malformed URLs on PHP 8.0+. Pre-existing fragility; deferred to a separate ticket.

### Does it affect (changes or update) any sensitive data?

No.

### How is it tested?

Automatic. `./bin/phpunit` runs the full suite (757 tests, 2326 assertions) on the PHP 7.2 dev image with all gates green. PHP 8.5 verified by running the same suite inside `php:8.5-cli-alpine` (with deprecation reporting suppressed). Static analysis (`./bin/phpcs` and `./bin/phpstan` level 6) is clean. CI now also runs `php -l` against PHP 8.5.

### How is it going to be deployed?

Standard deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAR-789]: https://sequra.atlassian.net/browse/PAR-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ