### PR TITLE
[PAR-778] Add optional active_theme to StoreInfo payload

### DIFF
--- a/src/BusinessLogic/Domain/Stores/Models/StoreInfo.php
+++ b/src/BusinessLogic/Domain/Stores/Models/StoreInfo.php
@@ -55,6 +55,11 @@ class StoreInfo
     private $plugins;
 
     /**
+     * @var string|null
+     */
+    private $activeTheme;
+
+    /**
      * @param string $storeName
      * @param string $storeUrl
      * @param string $platform
@@ -64,6 +69,7 @@ class StoreInfo
      * @param string $db
      * @param string $os
      * @param string[] $plugins
+     * @param string|null $activeTheme
      */
     public function __construct(
         string $storeName,
@@ -74,7 +80,8 @@ class StoreInfo
         string $phpVersion,
         string $db,
         string $os,
-        array $plugins = []
+        array $plugins = [],
+        ?string $activeTheme = null
     ) {
         $this->storeName = $storeName;
         $this->storeUrl = $storeUrl;
@@ -85,6 +92,7 @@ class StoreInfo
         $this->db = $db;
         $this->os = $os;
         $this->plugins = $plugins;
+        $this->activeTheme = $activeTheme;
     }
 
     /**
@@ -170,6 +178,14 @@ class StoreInfo
     }
 
     /**
+     * @return string|null
+     */
+    public function getActiveTheme(): ?string
+    {
+        return $this->activeTheme;
+    }
+
+    /**
      * Converts the model to an array.
      *
      * @return array<string, mixed>
@@ -186,6 +202,7 @@ class StoreInfo
             'db' => $this->db,
             'os' => $this->os,
             'plugins' => $this->plugins,
+            'active_theme' => $this->activeTheme,
         ];
     }
 
@@ -207,7 +224,8 @@ class StoreInfo
             $data['php_version'] ?? '',
             $data['db'] ?? '',
             $data['os'] ?? '',
-            $data['plugins'] ?? []
+            $data['plugins'] ?? [],
+            $data['active_theme'] ?? null
         );
     }
 }

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -517,7 +517,56 @@ class ConfigurationWebhookAPITest extends BaseTestCase
             'php_version' => '8.4',
             'db' => 'mysql',
             'os' => 'linux',
-            'plugins' => ['plugin1', 'plugin2', 'plugin3']
+            'plugins' => ['plugin1', 'plugin2', 'plugin3'],
+            'active_theme' => null
+        ], $response->toArray());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testStoreInfoResponseWithActiveTheme(): void
+    {
+        //Arrange
+
+        $this->storeInfoService->setMockStoreInfo(
+            new StoreInfo(
+                'Test Store',
+                'https://test.com',
+                'Test Platform',
+                'v1.0.0',
+                'v2.1',
+                '8.4',
+                'mysql',
+                'linux',
+                ['plugin1'],
+                'Storefront v3.2'
+            )
+        );
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                'topic' => 'get-store-info'
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEquals([
+            'store_name' => 'Test Store',
+            'store_url' => 'https://test.com',
+            'platform' => 'Test Platform',
+            'platform_version' => 'v1.0.0',
+            'plugin_version' => 'v2.1',
+            'php_version' => '8.4',
+            'db' => 'mysql',
+            'os' => 'linux',
+            'plugins' => ['plugin1'],
+            'active_theme' => 'Storefront v3.2'
         ], $response->toArray());
     }
 


### PR DESCRIPTION
### What is the goal?

Allow the `get-store-info` webhook payload to carry the merchant's currently active theme as an optional string. This is needed by the Shopify Marketing App effort under [PAR-778](https://sequra.atlassian.net/browse/PAR-778) (and is harmless to PHP plugins that don't have a theme to report).

The merchant portal already consumes this field as optional (companion PR [merchant-portal-frontend#1362](https://github.com/sequra/merchant-portal-frontend/pull/1362) — adds an "Active theme" row above the extensions list, conditionally rendered).

### References

* **Issue:** [PAR-778](https://sequra.atlassian.net/browse/PAR-778)
* **Related pull-requests:** [merchant-portal-frontend#1362](https://github.com/sequra/merchant-portal-frontend/pull/1362)
* **Sentry errors:** —
* **Any other references:** —

### How is it being implemented?

`src/BusinessLogic/Domain/Stores/Models/StoreInfo.php` — additive, non-breaking changes:

- New private property `$activeTheme` (nullable string).
- New constructor parameter `?string $activeTheme = null`, **appended as the last argument** so existing plugin code calling `new StoreInfo($name, $url, $platform, $platformVersion, $pluginVersion, $phpVersion, $db, $os, $plugins)` keeps compiling and behaving exactly as before.
- New getter `getActiveTheme(): ?string`.
- `toArray()` includes `'active_theme' => $this->activeTheme` (serialises to JSON `null` when not provided).
- `fromArray()` reads `$data['active_theme'] ?? null`, so older serialised payloads stay valid.

No changes to `GetStoreInfoHandler`, `StoreInfoResponse`, `StoreInfoServiceInterface`, or the `get-store-info` topic constant — the field rides through the existing pass-through path.

### Opportunistic refactorings

None — the change is intentionally minimal and additive.

### Caveats

- The existing 9-argument constructor signature is preserved by appending the new parameter at the end. Adding the parameter anywhere earlier in the signature **would break every plugin** that calls `new StoreInfo(...)` positionally.
- `toArray()` always emits the `active_theme` key (defaulting to `null`). Consumers that ignore unknown keys are fine; the merchant portal frontend already treats `active_theme` as optional and hides the row when null/empty.
- No interface method like `getActiveTheme()` is added to `StoreInfoServiceInterface`. Plugins opt in simply by passing the new constructor argument from their existing `getStoreInfo()` implementation — no forced migration.

### Does it affect (changes or update) any sensitive data?

No. The theme name is non-sensitive merchant configuration metadata, of the same nature as `platform_version` and `plugin_version` already in the payload.

### How is it tested?

Automatic tests in `tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php`:

- **Updated** `testStoreInfoResponse` — asserts the existing 9-arg construction now produces `'active_theme' => null` in the response.
- **Added** `testStoreInfoResponseWithActiveTheme` — constructs `StoreInfo` with `'Storefront v3.2'` as the active theme and asserts it round-trips through the webhook response.

Run locally with PHP 8.2 + the project's pinned PHPUnit 8.5.14:

```
vendor/bin/phpunit --filter "testStoreInfoResponse|testStoreInfoResponseWithActiveTheme" tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
# OK (2 tests, 4 assertions)
```

(On PHP 8.4 the suite triggers pre-existing nullable-parameter deprecations inside PHPUnit 8.5 internals — same on master, unrelated to this PR.)

### How is it going to be deployed?

Standard deployment — additive minor-version release. Suggested follow-up: bump `integration-middleware`'s `sequra/integration-core` constraint to the new version so downstream plugins pick it up.


[PAR-778]: https://sequra.atlassian.net/browse/PAR-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAR-778]: https://sequra.atlassian.net/browse/PAR-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ