### PR TITLE
[PAR-778] Avoid full StoreInfo computation when only storeUrl is needed for HMAC

### DIFF
--- a/src/BusinessLogic/Domain/Integration/StoreInfo/StoreUrlProviderInterface.php
+++ b/src/BusinessLogic/Domain/Integration/StoreInfo/StoreUrlProviderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo;
+
+/**
+ * Optional companion interface for {@see StoreInfoServiceInterface}.
+ *
+ * Webhook signature validation and HMAC computation in
+ * {@see \SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService}
+ * only need the storeUrl, not the full {@see \SeQura\Core\BusinessLogic\Domain\Stores\Models\StoreInfo}
+ * payload. Integrations whose
+ * {@see StoreInfoServiceInterface::getStoreInfo()} implementation is expensive
+ * (for example, when populating it requires live calls to the host platform
+ * to read fields the HMAC does not use) can additionally implement this
+ * interface to expose a cheap, side-effect-free storeUrl lookup for HMAC
+ * purposes.
+ *
+ * When implemented, {@see \SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService::signaturePayload()}
+ * calls {@see self::getStoreUrl()} instead of building a full StoreInfo via
+ * {@see StoreInfoServiceInterface::getStoreInfo()}, avoiding the cost of
+ * populating the full payload on every register / delete / inbound webhook.
+ *
+ * Implementing this interface is OPTIONAL and fully backwards-compatible —
+ * integrations that do NOT implement it continue to receive the storeUrl
+ * through the existing {@see StoreInfoServiceInterface::getStoreInfo()} path.
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo
+ */
+interface StoreUrlProviderInterface
+{
+    /**
+     * Returns the canonical storeUrl used in the webhook signature payload.
+     *
+     * Must produce the exact same value as
+     * {@see StoreInfoServiceInterface::getStoreInfo()}'s
+     * {@see \SeQura\Core\BusinessLogic\Domain\Stores\Models\StoreInfo::getStoreUrl()}
+     * would return for the current tenant context, otherwise webhook signature
+     * validation will fail.
+     *
+     * Implementations should be cheap and side-effect-free — typically a
+     * string built from the configured store domain.
+     *
+     * @return string
+     */
+    public function getStoreUrl(): string;
+}

--- a/src/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationService.php
+++ b/src/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationService.php
@@ -6,6 +6,7 @@ use SeQura\Core\BusinessLogic\Domain\Connection\Models\ConnectionData;
 use SeQura\Core\BusinessLogic\Domain\Connection\RepositoryContracts\ConnectionDataRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\HMAC\HMAC;
 use SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreInfoServiceInterface;
+use SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreUrlProviderInterface;
 use SeQura\Core\BusinessLogic\Domain\Integration\StoreIntegration\StoreIntegrationServiceInterface as IntegrationsStoreServiceInterface;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Exceptions\CapabilitiesEmptyException;
@@ -194,7 +195,27 @@ class StoreIntegrationService
     {
         return [
             StoreContext::getInstance()->getStoreId(),
-            $this->storeInfoService->getStoreInfo()->getStoreUrl(),
+            $this->resolveStoreUrl(),
         ];
+    }
+
+    /**
+     * Resolves the storeUrl used in the HMAC payload.
+     *
+     * Prefers {@see StoreUrlProviderInterface::getStoreUrl()} when the injected
+     * StoreInfo service implements it — that path is cheap and avoids building
+     * the full StoreInfo payload on every register / delete / webhook
+     * validation. Falls back to {@see StoreInfoServiceInterface::getStoreInfo()}
+     * for plugins that have not opted in, preserving backwards compatibility.
+     *
+     * @return string
+     */
+    private function resolveStoreUrl(): string
+    {
+        if ($this->storeInfoService instanceof StoreUrlProviderInterface) {
+            return $this->storeInfoService->getStoreUrl();
+        }
+
+        return $this->storeInfoService->getStoreInfo()->getStoreUrl();
     }
 }

--- a/tests/BusinessLogic/Common/MockComponents/MockStoreInfoAndUrlService.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockStoreInfoAndUrlService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\Common\MockComponents;
+
+use SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreInfoServiceInterface;
+use SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreUrlProviderInterface;
+use SeQura\Core\BusinessLogic\Domain\Stores\Models\StoreInfo;
+
+/**
+ * Mock that opts into the lightweight {@see StoreUrlProviderInterface} path
+ * alongside the legacy {@see StoreInfoServiceInterface} contract. Used to
+ * verify that {@see \SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService::signaturePayload()}
+ * prefers the cheap accessor when available and never falls back to
+ * {@see StoreInfoServiceInterface::getStoreInfo()} for HMAC purposes.
+ *
+ * @package Common\MockComponents
+ */
+class MockStoreInfoAndUrlService implements StoreInfoServiceInterface, StoreUrlProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $storeUrl;
+
+    /**
+     * @var int
+     */
+    private $getStoreUrlCallCount = 0;
+
+    /**
+     * @var int
+     */
+    private $getStoreInfoCallCount = 0;
+
+    /**
+     * @param string $storeUrl
+     */
+    public function __construct(string $storeUrl)
+    {
+        $this->storeUrl = $storeUrl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStoreUrl(): string
+    {
+        $this->getStoreUrlCallCount++;
+
+        return $this->storeUrl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStoreInfo(): StoreInfo
+    {
+        $this->getStoreInfoCallCount++;
+
+        return new StoreInfo(
+            'fallback-name',
+            $this->storeUrl,
+            '',
+            '',
+            '',
+            '',
+            '',
+            ''
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function getStoreUrlCallCount(): int
+    {
+        return $this->getStoreUrlCallCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStoreInfoCallCount(): int
+    {
+        return $this->getStoreInfoCallCount;
+    }
+}

--- a/tests/BusinessLogic/Common/MockComponents/MockStoreInfoService.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockStoreInfoService.php
@@ -18,10 +18,17 @@ class MockStoreInfoService implements StoreInfoServiceInterface
     private $storeInfo;
 
     /**
+     * @var int
+     */
+    private $getStoreInfoCallCount = 0;
+
+    /**
      * @inheritDoc
      */
     public function getStoreInfo(): StoreInfo
     {
+        $this->getStoreInfoCallCount++;
+
         if ($this->storeInfo) {
             return $this->storeInfo;
         }
@@ -46,5 +53,13 @@ class MockStoreInfoService implements StoreInfoServiceInterface
     public function setMockStoreInfo(StoreInfo $storeInfo): void
     {
         $this->storeInfo = $storeInfo;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStoreInfoCallCount(): int
+    {
+        return $this->getStoreInfoCallCount;
     }
 }

--- a/tests/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationServiceTest.php
+++ b/tests/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationServiceTest.php
@@ -20,6 +20,7 @@ use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
 use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionDataRepository;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockIntegrationStoreIntegrationService;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockStoreInfoAndUrlService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockStoreInfoService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockStoreIntegrationProxy;
 
@@ -293,5 +294,114 @@ class StoreIntegrationServiceTest extends BaseTestCase
         $second = $this->service->getWebhookSignature();
 
         self::assertEquals($first, $second);
+    }
+
+    /**
+     * When the injected StoreInfoService also implements
+     * {@see \SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreUrlProviderInterface},
+     * the HMAC computation should use the cheap getStoreUrl() path and never
+     * build a full StoreInfo. Integrations whose getStoreInfo() is expensive
+     * rely on this to keep webhook validation fast.
+     *
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     */
+    public function testSignaturePayloadPrefersStoreUrlProviderWhenAvailable(): void
+    {
+        $storeInfoService = new MockStoreInfoAndUrlService('https://shop.example.com');
+
+        $service = new StoreIntegrationService(
+            $this->storeIntegrationService,
+            $this->storeIntegrationProxy,
+            $this->connectionDataRepository,
+            $storeInfoService
+        );
+
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('123'));
+
+        $service->createStoreIntegration(new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        ));
+
+        self::assertSame(1, $storeInfoService->getStoreUrlCallCount(), 'getStoreUrl() should be used for the HMAC payload.');
+        self::assertSame(0, $storeInfoService->getStoreInfoCallCount(), 'getStoreInfo() should not be called when StoreUrlProviderInterface is available.');
+    }
+
+    /**
+     * Signatures produced via the legacy getStoreInfo() path and via the new
+     * getStoreUrl() opt-in path must be byte-identical for the same shop, so a
+     * plugin can adopt the optimisation without invalidating any previously
+     * issued webhook URL.
+     *
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     * @throws InvalidUrlException
+     */
+    public function testStoreUrlProviderProducesTheSameSignatureAsGetStoreInfo(): void
+    {
+        $this->storeIntegrationService->setMockWebhookUrl(new URL('https://test.com/webhook', []));
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('123'));
+
+        $this->service->createStoreIntegration(new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        ));
+        $legacySignature = $this->storeIntegrationProxy->getWebhookUrl()->getQueryByKey('signature')->getValue();
+
+        $proxy = new MockStoreIntegrationProxy();
+        $proxy->setMockCreateResponse(new CreateStoreIntegrationResponse('123'));
+
+        $optInService = new StoreIntegrationService(
+            $this->storeIntegrationService,
+            $proxy,
+            $this->connectionDataRepository,
+            new MockStoreInfoAndUrlService('https://shop.example.com')
+        );
+
+        $optInService->createStoreIntegration(new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        ));
+        $optInSignature = $proxy->getWebhookUrl()->getQueryByKey('signature')->getValue();
+
+        self::assertSame($legacySignature, $optInSignature);
+    }
+
+    /**
+     * A plugin that only implements the legacy StoreInfoServiceInterface keeps
+     * working — getStoreInfo() is called and its storeUrl flows into the
+     * signature. The new interface is a pure opt-in extension.
+     *
+     * @return void
+     *
+     * @throws CapabilitiesEmptyException
+     * @throws InvalidEnvironmentException
+     */
+    public function testSignaturePayloadFallsBackToGetStoreInfoWhenStoreUrlProviderIsNotImplemented(): void
+    {
+        $this->storeIntegrationService->setMockCapabilities([Capability::general()]);
+        $this->storeIntegrationProxy->setMockCreateResponse(new CreateStoreIntegrationResponse('123'));
+
+        $this->service->createStoreIntegration(new ConnectionData(
+            'sandbox',
+            'merchant',
+            'svea',
+            new AuthorizationCredentials('username', 'password')
+        ));
+
+        self::assertSame(1, $this->storeInfoService->getStoreInfoCallCount(), 'Legacy plugins must still go through getStoreInfo().');
     }
 }


### PR DESCRIPTION
### What is the goal?

Stop forcing plugins to build a full `StoreInfo` payload on every webhook signature computation. `StoreIntegrationService::signaturePayload()` only needs `storeUrl` for the HMAC, but the legacy code path calls the full `StoreInfoServiceInterface::getStoreInfo()` to read it. For plugins whose `getStoreInfo()` is cheap this is fine; for plugins that fetch live data (e.g. the new SMA `StoreInfoService` that pulls the Shopify display name + active theme on every call) it triples the per-webhook outbound API traffic for no functional benefit.

### References

* **Issue:** https://sequra.atlassian.net/browse/PAR-778
* **Related pull-requests:** sequra/integration-core#61 (active_theme addition, which made the SMA `getStoreInfo()` expensive in the first place); sequra/shopify-marketing-app#122 (will opt into the new interface once this lands).

### How is it being implemented?

* New optional companion interface `\SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreUrlProviderInterface` with a single method `getStoreUrl(): string`.
* `StoreIntegrationService::signaturePayload()` now delegates to a private `resolveStoreUrl()` helper that prefers `StoreUrlProviderInterface::getStoreUrl()` when the injected `StoreInfoServiceInterface` also implements it, and falls back to `getStoreInfo()->getStoreUrl()` otherwise.
* Plugins opt in by adding `implements StoreUrlProviderInterface` to their existing service and providing a cheap implementation (typically `return $shop !== '' ? 'https://'.$shop : '';`).

### Backwards compatibility

* `StoreInfoServiceInterface` is untouched — every existing plugin (WooCommerce, PrestaShop, Magento, …) keeps compiling and behaves identically.
* The new interface is pure-additive. A plugin that does not adopt it gets the same behaviour as today: `getStoreInfo()` is called, `storeUrl` is read off the result.
* Signatures produced via the legacy path and via the opt-in path are byte-identical for the same shop, so a plugin can switch mid-stream without invalidating any previously-issued webhook URL (asserted by `testStoreUrlProviderProducesTheSameSignatureAsGetStoreInfo`).

### Caveats

* Implementers of `StoreUrlProviderInterface::getStoreUrl()` MUST return the exact same string as `getStoreInfo()->getStoreUrl()` would for the current tenant context — otherwise webhook signature validation will fail. This is documented on the interface.

### Does it affect (changes or update) any sensitive data?

No. The change is entirely structural — the HMAC payload, signature secret, and inbound webhook validation behaviour are unchanged.

### How is it tested?

Automated, in `tests/BusinessLogic/Domain/StoreIntegration/Services/StoreIntegrationServiceTest.php`:

- `testSignaturePayloadPrefersStoreUrlProviderWhenAvailable` — when both interfaces are implemented, `getStoreUrl()` is invoked and `getStoreInfo()` is **not** called (call counts asserted).
- `testStoreUrlProviderProducesTheSameSignatureAsGetStoreInfo` — signatures emitted via the legacy path and via the opt-in path match byte-for-byte for the same shop.
- `testSignaturePayloadFallsBackToGetStoreInfoWhenStoreUrlProviderIsNotImplemented` — plugins that have not opted in keep using `getStoreInfo()`; legacy behaviour preserved.

Full suite: `vendor/bin/phpunit` → 763 tests, 2337 assertions, all green. `vendor/bin/phpstan analyse --memory-limit=512M` → clean.

### How is it going to be deployed?

Standard deployment. Tag a new minor version of `sequra/integration-core` (`5.3.0`) once merged; downstream plugins can adopt the optimisation at their own pace by bumping their dependency and implementing the new interface.
