### PR TITLE
[QRD-7899] feat(configuration-webhook): add affiliate config topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+# [v5.5.0](https://github.com/sequra/integration-core/tree/v5.5.0)
+## Added
+- Affiliate configuration support: the `AffiliateSettings` entity and `AffiliateSettingsService`, the `get-affiliate-settings` and `save-affiliate-settings` configuration webhook topics, and connect time provisioning that reads the `affiliate` block from the merchant `configuration_data` and persists it.
+
 # [v1.0.13](https://github.com/sequra/integration-core/tree/v1.0.13)
 ## Changed
 - Added compatibility with PHP8.2.

--- a/README.md
+++ b/README.md
@@ -3171,6 +3171,8 @@ The Configuration WebhookAPI follows a **simplified Controller pattern** with **
     - **GetShopProductsHandler**: Handles `get-shop-products` webhook topic
     - **GetStoreInfoHandler**: Handles `get-store-info` webhook topic
     - **SaveWidgetSettingsHandler**: Handles `save-widget-settings` webhook topic
+    - **GetAffiliateSettingsHandler**: Handles `get-affiliate-settings` webhook topic
+    - **SaveAffiliateSettingsHandler**: Handles `save-affiliate-settings` webhook topic
   
 #### Webhook Processing Flow
 

--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -21,6 +21,8 @@ use SeQura\Core\BusinessLogic\CheckoutAPI\Solicitation\Controller\SolicitationCo
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Controller\ConfigurationWebhookController;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\AdvancedSettings\GetAdvancedSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\AdvancedSettings\SaveAdvancedSettingsHandler;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate\GetAffiliateSettingsHandler;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate\SaveAffiliateSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\BannerSettings\GetBannerSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\BannerSettings\SaveBannerSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Enums\Topics;
@@ -40,6 +42,8 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\Ge
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\SaveWidgetSettingsHandler;
 use SeQura\Core\BusinessLogic\DataAccess\AdvancedSettings\Entities\AdvancedSettings;
 use SeQura\Core\BusinessLogic\DataAccess\AdvancedSettings\Repositories\AdvancedSettingsRepository;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Repositories\AffiliateSettingsRepository;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Entities\BannerSettings;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Repositories\BannerSettingsRepository;
 use SeQura\Core\BusinessLogic\DataAccess\ConnectionData\Entities\ConnectionData;
@@ -67,6 +71,8 @@ use SeQura\Core\BusinessLogic\DataAccess\TransactionLog\Repositories\Transaction
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\RepositoryContracts\AdvancedSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Services\AdvancedLoggerSettingsProvider;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Services\AdvancedSettingsService;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\RepositoryContracts\BannerSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Services\BannerSettingsService;
 use SeQura\Core\BusinessLogic\Domain\Integration\Banner\BannerServiceInterface;
@@ -328,6 +334,16 @@ class BootstrapComponent extends BaseBootstrapComponent
             static function () {
                 return new AdvancedSettingsRepository(
                     RepositoryRegistry::getRepository(AdvancedSettings::getClassName()),
+                    ServiceRegister::getService(StoreContext::class)
+                );
+            }
+        );
+
+        ServiceRegister::registerService(
+            AffiliateSettingsRepositoryInterface::class,
+            static function () {
+                return new AffiliateSettingsRepository(
+                    RepositoryRegistry::getRepository(AffiliateSettings::getClassName()),
                     ServiceRegister::getService(StoreContext::class)
                 );
             }
@@ -663,6 +679,15 @@ class BootstrapComponent extends BaseBootstrapComponent
             static function () {
                 return new AdvancedSettingsService(
                     ServiceRegister::getService(AdvancedSettingsRepositoryInterface::class)
+                );
+            }
+        );
+
+        ServiceRegister::registerService(
+            AffiliateSettingsService::class,
+            static function () {
+                return new AffiliateSettingsService(
+                    ServiceRegister::getService(AffiliateSettingsRepositoryInterface::class)
                 );
             }
         );
@@ -1057,6 +1082,16 @@ class BootstrapComponent extends BaseBootstrapComponent
         );
 
         TopicHandlerRegistry::register(
+            Topics::GET_AFFILIATE_SETTINGS,
+            GetAffiliateSettingsHandler::class
+        );
+
+        TopicHandlerRegistry::register(
+            Topics::SAVE_AFFILIATE_SETTINGS,
+            SaveAffiliateSettingsHandler::class
+        );
+
+        TopicHandlerRegistry::register(
             Topics::GET_BANNER_SETTINGS,
             GetBannerSettingsHandler::class
         );
@@ -1185,6 +1220,24 @@ class BootstrapComponent extends BaseBootstrapComponent
             static function () {
                 return new SaveAdvancedSettingsHandler(
                     ServiceRegister::getService(AdvancedSettingsService::class)
+                );
+            }
+        );
+
+        ServiceRegister::registerService(
+            GetAffiliateSettingsHandler::class,
+            static function () {
+                return new GetAffiliateSettingsHandler(
+                    ServiceRegister::getService(AffiliateSettingsService::class)
+                );
+            }
+        );
+
+        ServiceRegister::registerService(
+            SaveAffiliateSettingsHandler::class,
+            static function () {
+                return new SaveAffiliateSettingsHandler(
+                    ServiceRegister::getService(AffiliateSettingsService::class)
                 );
             }
         );

--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -400,7 +400,8 @@ class BootstrapComponent extends BaseBootstrapComponent
                     ServiceRegister::getService(ConnectionProxyInterface::class),
                     ServiceRegister::getService(CredentialsRepositoryInterface::class),
                     ServiceRegister::getService(CountryConfigurationRepositoryInterface::class),
-                    ServiceRegister::getService(PaymentMethodRepositoryInterface::class)
+                    ServiceRegister::getService(PaymentMethodRepositoryInterface::class),
+                    ServiceRegister::getService(AffiliateSettingsService::class)
                 );
             }
         );

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/GetAffiliateSettingsHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/GetAffiliateSettingsHandler.php
@@ -5,7 +5,6 @@ namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate;
 use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\TopicHandlerInterface;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\Affiliate\AffiliateSettingsResponse;
-use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\SuccessResponse;
 use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 
 /**
@@ -35,12 +34,9 @@ class GetAffiliateSettingsHandler implements TopicHandlerInterface
      */
     public function handle(array $payload): Response
     {
-        $affiliateSettings = $this->affiliateSettingsService->getAffiliateSettings();
-
-        if (!$affiliateSettings) {
-            return new SuccessResponse();
-        }
-
-        return new AffiliateSettingsResponse($affiliateSettings);
+        // GET is a boolean-state read: return only whether the feature is enabled, never echo the
+        // offer id or security token. The service always yields settings (disabled by default when
+        // none are stored), so the response is enabled=false when nothing is configured.
+        return new AffiliateSettingsResponse($this->affiliateSettingsService->getAffiliateSettings()->isEnabled());
     }
 }

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/GetAffiliateSettingsHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/GetAffiliateSettingsHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate;
+
+use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\TopicHandlerInterface;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\Affiliate\AffiliateSettingsResponse;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\SuccessResponse;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
+
+/**
+ * Class GetAffiliateSettingsHandler
+ *
+ * @package SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate
+ */
+class GetAffiliateSettingsHandler implements TopicHandlerInterface
+{
+    /**
+     * @var AffiliateSettingsService
+     */
+    protected $affiliateSettingsService;
+
+    /**
+     * @param AffiliateSettingsService $affiliateSettingsService
+     */
+    public function __construct(AffiliateSettingsService $affiliateSettingsService)
+    {
+        $this->affiliateSettingsService = $affiliateSettingsService;
+    }
+
+    /**
+     * @param mixed[] $payload
+     *
+     * @return Response
+     */
+    public function handle(array $payload): Response
+    {
+        $affiliateSettings = $this->affiliateSettingsService->getAffiliateSettings();
+
+        if (!$affiliateSettings) {
+            return new SuccessResponse();
+        }
+
+        return new AffiliateSettingsResponse($affiliateSettings);
+    }
+}

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/SaveAffiliateSettingsHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Affiliate/SaveAffiliateSettingsHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate;
+
+use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\TopicHandlerInterface;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\Affiliate\SaveAffiliateSettingsRequest;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\SuccessResponse;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
+
+/**
+ * Class SaveAffiliateSettingsHandler
+ *
+ * @package SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate
+ */
+class SaveAffiliateSettingsHandler implements TopicHandlerInterface
+{
+    /**
+     * @var AffiliateSettingsService
+     */
+    protected $affiliateSettingsService;
+
+    /**
+     * @param AffiliateSettingsService $affiliateSettingsService
+     */
+    public function __construct(AffiliateSettingsService $affiliateSettingsService)
+    {
+        $this->affiliateSettingsService = $affiliateSettingsService;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(array $payload): Response
+    {
+        $request = SaveAffiliateSettingsRequest::fromPayload($payload);
+        $this->affiliateSettingsService->setAffiliateSettings($request->transformToDomainModel());
+
+        return new SuccessResponse();
+    }
+}

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Enums/Topics.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/Enums/Topics.php
@@ -78,6 +78,14 @@ interface Topics
      */
     public const GET_STORE_INFO = 'get-store-info';
     /**
+     * @var string
+     */
+    public const GET_AFFILIATE_SETTINGS = 'get-affiliate-settings';
+    /**
+     * @var string
+     */
+    public const SAVE_AFFILIATE_SETTINGS = 'save-affiliate-settings';
+    /**
      * @var string[]
      */
     public const ALL_TOPICS = [
@@ -97,6 +105,8 @@ interface Topics
         self::GET_SHOP_CATEGORIES,
         self::GET_SHOP_PRODUCTS,
         self::GET_SELLING_COUNTRIES,
-        self::GET_STORE_INFO
+        self::GET_STORE_INFO,
+        self::GET_AFFILIATE_SETTINGS,
+        self::SAVE_AFFILIATE_SETTINGS
     ];
 }

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Requests/Affiliate/SaveAffiliateSettingsRequest.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Requests/Affiliate/SaveAffiliateSettingsRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\Affiliate;
+
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\ConfigurationWebhookRequest;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+
+/**
+ * Class SaveAffiliateSettingsRequest.
+ *
+ * @package SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\Affiliate
+ */
+class SaveAffiliateSettingsRequest extends ConfigurationWebhookRequest
+{
+    /**
+     * @var bool $isEnabled
+     */
+    private $isEnabled;
+
+    /**
+     * @var string $offerId
+     */
+    private $offerId;
+
+    /**
+     * @var string $securityToken
+     */
+    private $securityToken;
+
+    /**
+     * @param bool $isEnabled
+     * @param string $offerId
+     * @param string $securityToken
+     */
+    public function __construct(bool $isEnabled, string $offerId, string $securityToken)
+    {
+        $this->isEnabled = $isEnabled;
+        $this->offerId = $offerId;
+        $this->securityToken = $securityToken;
+    }
+
+    /**
+     * @param mixed[] $payload
+     *
+     * @return self
+     */
+    public static function fromPayload(array $payload): object
+    {
+        return new self(
+            $payload['isEnabled'] ?? false,
+            (string)($payload['offerId'] ?? ''),
+            (string)($payload['securityToken'] ?? '')
+        );
+    }
+
+    /**
+     * @return AffiliateSettings
+     */
+    public function transformToDomainModel(): AffiliateSettings
+    {
+        return new AffiliateSettings($this->isEnabled, $this->offerId, $this->securityToken);
+    }
+}

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Responses/Affiliate/AffiliateSettingsResponse.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Responses/Affiliate/AffiliateSettingsResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\Affiliate;
+
+use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+
+/**
+ * Class AffiliateSettingsResponse
+ *
+ * @package SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\Affiliate
+ */
+class AffiliateSettingsResponse extends Response
+{
+    /**
+     * @var AffiliateSettings $settings
+     */
+    protected $settings;
+
+    /**
+     * @param ?AffiliateSettings $settings
+     */
+    public function __construct(?AffiliateSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(): array
+    {
+        return !$this->settings ? [] : $this->settings->toArray();
+    }
+}

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Responses/Affiliate/AffiliateSettingsResponse.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Responses/Affiliate/AffiliateSettingsResponse.php
@@ -3,7 +3,6 @@
 namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\Affiliate;
 
 use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
-use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
 
 /**
  * Class AffiliateSettingsResponse
@@ -13,16 +12,16 @@ use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
 class AffiliateSettingsResponse extends Response
 {
     /**
-     * @var AffiliateSettings $settings
+     * @var bool $isEnabled
      */
-    protected $settings;
+    protected $isEnabled;
 
     /**
-     * @param ?AffiliateSettings $settings
+     * @param bool $isEnabled
      */
-    public function __construct(?AffiliateSettings $settings)
+    public function __construct(bool $isEnabled)
     {
-        $this->settings = $settings;
+        $this->isEnabled = $isEnabled;
     }
 
     /**
@@ -30,6 +29,6 @@ class AffiliateSettingsResponse extends Response
      */
     public function toArray(): array
     {
-        return !$this->settings ? [] : $this->settings->toArray();
+        return ['isEnabled' => $this->isEnabled];
     }
 }

--- a/src/BusinessLogic/DataAccess/Affiliate/Entities/AffiliateSettings.php
+++ b/src/BusinessLogic/DataAccess/Affiliate/Entities/AffiliateSettings.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities;
+
+use SeQura\Core\Infrastructure\ORM\Configuration\EntityConfiguration;
+use SeQura\Core\Infrastructure\ORM\Configuration\IndexMap;
+use SeQura\Core\Infrastructure\ORM\Entity;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings as DomainAffiliateSettings;
+
+/**
+ * Class AffiliateSettings.
+ *
+ * @package SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities
+ */
+class AffiliateSettings extends Entity
+{
+    /**
+     * Fully qualified name of this class.
+     */
+    public const CLASS_NAME = __CLASS__;
+
+    /**
+     * @var string
+     */
+    protected $storeId;
+
+    /**
+     * @var DomainAffiliateSettings
+     */
+    protected $affiliateSettings;
+
+    /**
+     * @inheritDoc
+     */
+    public function inflate(array $data): void
+    {
+        parent::inflate($data);
+
+        $affiliateSettings = $data['affiliateSettings'] ?? [];
+        $this->storeId = $data['storeId'] ?? '';
+
+        $this->affiliateSettings = new DomainAffiliateSettings(
+            (bool)self::getDataValue($affiliateSettings, 'isEnabled', false),
+            (string)self::getDataValue($affiliateSettings, 'offerId', ''),
+            (string)self::getDataValue($affiliateSettings, 'securityToken', '')
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['storeId'] = $this->storeId;
+        $data['affiliateSettings'] = [
+            'isEnabled' => $this->affiliateSettings->isEnabled(),
+            'offerId' => $this->affiliateSettings->getOfferId(),
+            'securityToken' => $this->affiliateSettings->getSecurityToken()
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConfig(): EntityConfiguration
+    {
+        $indexMap = new IndexMap();
+
+        $indexMap->addStringIndex('storeId');
+
+        return new EntityConfiguration($indexMap, 'AffiliateSettings');
+    }
+
+    /**
+     * @return string
+     */
+    public function getStoreId(): string
+    {
+        return $this->storeId;
+    }
+
+    /**
+     * @param string $storeId
+     */
+    public function setStoreId(string $storeId): void
+    {
+        $this->storeId = $storeId;
+    }
+
+    /**
+     * @return DomainAffiliateSettings
+     */
+    public function getAffiliateSettings(): DomainAffiliateSettings
+    {
+        return $this->affiliateSettings;
+    }
+
+    /**
+     * @param DomainAffiliateSettings $affiliateSettings
+     */
+    public function setAffiliateSettings(DomainAffiliateSettings $affiliateSettings): void
+    {
+        $this->affiliateSettings = $affiliateSettings;
+    }
+}

--- a/src/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepository.php
+++ b/src/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepository.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\DataAccess\Affiliate\Repositories;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\Core\Infrastructure\ORM\Exceptions\QueryFilterInvalidParamException;
+use SeQura\Core\Infrastructure\ORM\Interfaces\RepositoryInterface;
+use SeQura\Core\Infrastructure\ORM\QueryFilter\Operators;
+use SeQura\Core\Infrastructure\ORM\QueryFilter\QueryFilter;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings as AffiliateSettingsEntity;
+
+/**
+ * Class AffiliateSettingsRepository.
+ *
+ * @package SeQura\Core\BusinessLogic\DataAccess\Affiliate\Repositories
+ */
+class AffiliateSettingsRepository implements AffiliateSettingsRepositoryInterface
+{
+    /**
+     * @var RepositoryInterface Affiliate settings repository.
+     */
+    protected $repository;
+
+    /**
+     * @var StoreContext Store context needed for multistore environment.
+     */
+    protected $storeContext;
+
+    /**
+     * @param RepositoryInterface $repository
+     * @param StoreContext $storeContext
+     */
+    public function __construct(RepositoryInterface $repository, StoreContext $storeContext)
+    {
+        $this->repository = $repository;
+        $this->storeContext = $storeContext;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws QueryFilterInvalidParamException
+     */
+    public function getAffiliateSettings(): ?AffiliateSettings
+    {
+        $entity = $this->getAffiliateSettingsEntity();
+
+        return $entity ? $entity->getAffiliateSettings() : null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws QueryFilterInvalidParamException
+     */
+    public function setAffiliateSettings(AffiliateSettings $settings): void
+    {
+        $existingAffiliateSettings = $this->getAffiliateSettingsEntity();
+
+        if ($existingAffiliateSettings) {
+            $existingAffiliateSettings->setAffiliateSettings($settings);
+            $existingAffiliateSettings->setStoreId($this->storeContext->getStoreId());
+            $this->repository->update($existingAffiliateSettings);
+
+            return;
+        }
+
+        $entity = new AffiliateSettingsEntity();
+        $entity->setStoreId($this->storeContext->getStoreId());
+        $entity->setAffiliateSettings($settings);
+        $this->repository->save($entity);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws QueryFilterInvalidParamException
+     */
+    public function deleteAffiliateSettings(): void
+    {
+        $entity = $this->getAffiliateSettingsEntity();
+
+        $entity && $this->repository->delete($entity);
+    }
+
+    /**
+     * Gets the affiliate settings entity from the database.
+     *
+     * @return ?AffiliateSettingsEntity
+     *
+     * @throws QueryFilterInvalidParamException
+     */
+    protected function getAffiliateSettingsEntity(): ?AffiliateSettingsEntity
+    {
+        $queryFilter = new QueryFilter();
+        $queryFilter->where('storeId', Operators::EQUALS, $this->storeContext->getStoreId());
+
+        /**
+         * @var AffiliateSettingsEntity $affiliateSettings
+         */
+        $affiliateSettings = $this->repository->selectOne($queryFilter);
+
+        return $affiliateSettings;
+    }
+}

--- a/src/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepository.php
+++ b/src/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepository.php
@@ -74,18 +74,6 @@ class AffiliateSettingsRepository implements AffiliateSettingsRepositoryInterfac
     }
 
     /**
-     * @return void
-     *
-     * @throws QueryFilterInvalidParamException
-     */
-    public function deleteAffiliateSettings(): void
-    {
-        $entity = $this->getAffiliateSettingsEntity();
-
-        $entity && $this->repository->delete($entity);
-    }
-
-    /**
      * Gets the affiliate settings entity from the database.
      *
      * @return ?AffiliateSettingsEntity

--- a/src/BusinessLogic/Domain/Affiliate/Models/AffiliateSettings.php
+++ b/src/BusinessLogic/Domain/Affiliate/Models/AffiliateSettings.php
@@ -29,7 +29,10 @@ class AffiliateSettings
      */
     public function __construct(bool $isEnabled, string $offerId, string $securityToken)
     {
-        $this->isEnabled = $isEnabled;
+        // "Enabled" requires credentials: an enabled flag with no offer id or security token is not
+        // usable, so it is coerced to disabled. This keeps isEnabled() trustworthy for every consumer
+        // (postback gating, config provider) without each one having to re-check the credentials.
+        $this->isEnabled = $isEnabled && '' !== $offerId && '' !== $securityToken;
         $this->offerId = $offerId;
         $this->securityToken = $securityToken;
     }

--- a/src/BusinessLogic/Domain/Affiliate/Models/AffiliateSettings.php
+++ b/src/BusinessLogic/Domain/Affiliate/Models/AffiliateSettings.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Affiliate\Models;
+
+/**
+ * Class AffiliateSettings.
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Affiliate\Models
+ */
+class AffiliateSettings
+{
+    /**
+     * @var bool $isEnabled
+     */
+    private $isEnabled;
+    /**
+     * @var string $offerId
+     */
+    private $offerId;
+    /**
+     * @var string $securityToken
+     */
+    private $securityToken;
+
+    /**
+     * @param bool $isEnabled
+     * @param string $offerId
+     * @param string $securityToken
+     */
+    public function __construct(bool $isEnabled, string $offerId, string $securityToken)
+    {
+        $this->isEnabled = $isEnabled;
+        $this->offerId = $offerId;
+        $this->securityToken = $securityToken;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOfferId(): string
+    {
+        return $this->offerId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecurityToken(): string
+    {
+        return $this->securityToken;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'isEnabled' => $this->isEnabled,
+            'offerId' => $this->offerId,
+            'securityToken' => $this->securityToken,
+        ];
+    }
+}

--- a/src/BusinessLogic/Domain/Affiliate/RepositoryContracts/AffiliateSettingsRepositoryInterface.php
+++ b/src/BusinessLogic/Domain/Affiliate/RepositoryContracts/AffiliateSettingsRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+
+/**
+ * Interface AffiliateSettingsRepositoryInterface.
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts
+ */
+interface AffiliateSettingsRepositoryInterface
+{
+    /**
+     * @return ?AffiliateSettings
+     */
+    public function getAffiliateSettings(): ?AffiliateSettings;
+
+    /**
+     * @param AffiliateSettings $settings
+     *
+     * @return void
+     */
+    public function setAffiliateSettings(AffiliateSettings $settings): void;
+
+    /**
+     * @return void
+     */
+    public function deleteAffiliateSettings(): void;
+}

--- a/src/BusinessLogic/Domain/Affiliate/RepositoryContracts/AffiliateSettingsRepositoryInterface.php
+++ b/src/BusinessLogic/Domain/Affiliate/RepositoryContracts/AffiliateSettingsRepositoryInterface.php
@@ -22,9 +22,4 @@ interface AffiliateSettingsRepositoryInterface
      * @return void
      */
     public function setAffiliateSettings(AffiliateSettings $settings): void;
-
-    /**
-     * @return void
-     */
-    public function deleteAffiliateSettings(): void;
 }

--- a/src/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsService.php
+++ b/src/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsService.php
@@ -26,11 +26,14 @@ class AffiliateSettingsService
     }
 
     /**
-     * @return ?AffiliateSettings
+     * Returns the stored affiliate settings, or a safe disabled default when none are stored, so
+     * consumers never have to null-check and "absent" deterministically means disabled.
+     *
+     * @return AffiliateSettings
      */
-    public function getAffiliateSettings(): ?AffiliateSettings
+    public function getAffiliateSettings(): AffiliateSettings
     {
-        return $this->affiliateSettingsRepository->getAffiliateSettings();
+        return $this->affiliateSettingsRepository->getAffiliateSettings() ?? new AffiliateSettings(false, '', '');
     }
 
     /**

--- a/src/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsService.php
+++ b/src/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\Affiliate\Services;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
+
+/**
+ * Class AffiliateSettingsService.
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\Affiliate\Services
+ */
+class AffiliateSettingsService
+{
+    /**
+     * @var AffiliateSettingsRepositoryInterface $affiliateSettingsRepository
+     */
+    private $affiliateSettingsRepository;
+
+    /**
+     * @param AffiliateSettingsRepositoryInterface $affiliateSettingsRepository
+     */
+    public function __construct(AffiliateSettingsRepositoryInterface $affiliateSettingsRepository)
+    {
+        $this->affiliateSettingsRepository = $affiliateSettingsRepository;
+    }
+
+    /**
+     * @return ?AffiliateSettings
+     */
+    public function getAffiliateSettings(): ?AffiliateSettings
+    {
+        return $this->affiliateSettingsRepository->getAffiliateSettings();
+    }
+
+    /**
+     * @param AffiliateSettings $affiliateSettings
+     *
+     * @return void
+     */
+    public function setAffiliateSettings(AffiliateSettings $affiliateSettings): void
+    {
+        $this->affiliateSettingsRepository->setAffiliateSettings($affiliateSettings);
+    }
+}

--- a/src/BusinessLogic/Domain/Connection/Models/Credentials.php
+++ b/src/BusinessLogic/Domain/Connection/Models/Credentials.php
@@ -98,7 +98,7 @@ class Credentials extends DataTransferObject
     }
 
     /**
-     * @return array<string>
+     * @return array<string, mixed>
      */
     public function getPayload(): array
     {

--- a/src/BusinessLogic/Domain/Connection/Services/CredentialsService.php
+++ b/src/BusinessLogic/Domain/Connection/Services/CredentialsService.php
@@ -2,6 +2,8 @@
 
 namespace SeQura\Core\BusinessLogic\Domain\Connection\Services;
 
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\BadMerchantIdException;
 use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\CredentialsNotFoundException;
 use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\WrongCredentialsException;
@@ -44,21 +46,29 @@ class CredentialsService
     protected $paymentMethodRepository;
 
     /**
+     * @var AffiliateSettingsService
+     */
+    protected $affiliateSettingsService;
+
+    /**
      * @param ConnectionProxyInterface $connectionProxy
      * @param CredentialsRepositoryInterface $credentialsRepository
      * @param CountryConfigurationRepositoryInterface $countryConfigurationRepository
      * @param PaymentMethodRepositoryInterface $paymentMethodRepository
+     * @param AffiliateSettingsService $affiliateSettingsService
      */
     public function __construct(
         ConnectionProxyInterface $connectionProxy,
         CredentialsRepositoryInterface $credentialsRepository,
         CountryConfigurationRepositoryInterface $countryConfigurationRepository,
-        PaymentMethodRepositoryInterface $paymentMethodRepository
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        AffiliateSettingsService $affiliateSettingsService
     ) {
         $this->connectionProxy = $connectionProxy;
         $this->credentialsRepository = $credentialsRepository;
         $this->countryConfigurationRepository = $countryConfigurationRepository;
         $this->paymentMethodRepository = $paymentMethodRepository;
+        $this->affiliateSettingsService = $affiliateSettingsService;
     }
 
     /**
@@ -85,8 +95,38 @@ class CredentialsService
 
         $this->credentialsRepository->deleteCredentialsByDeploymentId($connectionData->getDeployment());
         $this->credentialsRepository->setCredentials($credentials);
+        $this->updateAffiliateSettingsFromCredentials($credentials);
 
         return $credentials;
+    }
+
+    /**
+     * Persists the affiliate settings carried in the connect-time configuration_data, when present.
+     *
+     * The block is merchant-level (identical across the per-country credentials), so the first one
+     * that carries it wins. When no credential carries an affiliate block (e.g. the merchant API has
+     * not started emitting it yet) the stored settings are left untouched.
+     *
+     * @param Credentials[] $credentials
+     *
+     * @return void
+     */
+    private function updateAffiliateSettingsFromCredentials(array $credentials): void
+    {
+        foreach ($credentials as $credential) {
+            $affiliate = $credential->getPayload()['affiliate'] ?? null;
+            if (!\is_array($affiliate)) {
+                continue;
+            }
+
+            $this->affiliateSettingsService->setAffiliateSettings(new AffiliateSettings(
+                (bool)($affiliate['enabled'] ?? false),
+                (string)($affiliate['offer_id'] ?? ''),
+                (string)($affiliate['security_token'] ?? '')
+            ));
+
+            return;
+        }
     }
 
     /**

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -42,6 +42,7 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\Ge
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\SaveWidgetSettingsHandler;
 use SeQura\Core\BusinessLogic\DataAccess\AdvancedSettings\Entities\AdvancedSettings;
 use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Repositories\AffiliateSettingsRepository;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Entities\BannerSettings;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Repositories\BannerSettingsRepository;
 use SeQura\Core\BusinessLogic\DataAccess\ConnectionData\Entities\ConnectionData;
@@ -66,6 +67,7 @@ use SeQura\Core\BusinessLogic\DataAccess\StatisticalData\Repositories\Statistica
 use SeQura\Core\BusinessLogic\DataAccess\TransactionLog\Entities\TransactionLog;
 use SeQura\Core\BusinessLogic\DataAccess\TransactionLog\Repositories\TransactionLogRepository;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Services\AdvancedSettingsService;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\RepositoryContracts\BannerSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Services\BannerSettingsService;
@@ -304,12 +306,24 @@ class BaseTestCase extends TestCase
                     TestServiceRegister::getService(StoreIntegrationService::class)
                 );
             },
+            AffiliateSettingsRepositoryInterface::class => function () {
+                return new AffiliateSettingsRepository(
+                    TestRepositoryRegistry::getRepository(AffiliateSettings::getClassName()),
+                    StoreContext::getInstance()
+                );
+            },
+            AffiliateSettingsService::class => static function () {
+                return new AffiliateSettingsService(
+                    TestServiceRegister::getService(AffiliateSettingsRepositoryInterface::class)
+                );
+            },
             CredentialsService::class => static function () {
                 return new CredentialsService(
                     TestServiceRegister::getService(ConnectionProxyInterface::class),
                     TestServiceRegister::getService(CredentialsRepositoryInterface::class),
                     TestServiceRegister::getService(CountryConfigurationRepositoryInterface::class),
-                    TestServiceRegister::getService(PaymentMethodRepositoryInterface::class)
+                    TestServiceRegister::getService(PaymentMethodRepositoryInterface::class),
+                    TestServiceRegister::getService(AffiliateSettingsService::class)
                 );
             },
             PaymentMethodsService::class => static function () {

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -21,6 +21,8 @@ use SeQura\Core\BusinessLogic\CheckoutAPI\PromotionalWidgets\PromotionalWidgetsC
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Controller\ConfigurationWebhookController;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\AdvancedSettings\GetAdvancedSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\AdvancedSettings\SaveAdvancedSettingsHandler;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate\GetAffiliateSettingsHandler;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Affiliate\SaveAffiliateSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\BannerSettings\GetBannerSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\BannerSettings\SaveBannerSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\Enums\Topics;
@@ -39,6 +41,7 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\TopicHandlerRegis
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\GetWidgetSettingsHandler;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\WidgetSettings\SaveWidgetSettingsHandler;
 use SeQura\Core\BusinessLogic\DataAccess\AdvancedSettings\Entities\AdvancedSettings;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Entities\BannerSettings;
 use SeQura\Core\BusinessLogic\DataAccess\BannerSettings\Repositories\BannerSettingsRepository;
 use SeQura\Core\BusinessLogic\DataAccess\ConnectionData\Entities\ConnectionData;
@@ -63,6 +66,7 @@ use SeQura\Core\BusinessLogic\DataAccess\StatisticalData\Repositories\Statistica
 use SeQura\Core\BusinessLogic\DataAccess\TransactionLog\Entities\TransactionLog;
 use SeQura\Core\BusinessLogic\DataAccess\TransactionLog\Repositories\TransactionLogRepository;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Services\AdvancedSettingsService;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\RepositoryContracts\BannerSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Services\BannerSettingsService;
 use SeQura\Core\BusinessLogic\Domain\Connection\ProxyContracts\ConnectionProxyInterface;
@@ -857,6 +861,24 @@ class BaseTestCase extends TestCase
         );
 
         TestServiceRegister::registerService(
+            GetAffiliateSettingsHandler::class,
+            static function () {
+                return new GetAffiliateSettingsHandler(
+                    TestServiceRegister::getService(AffiliateSettingsService::class)
+                );
+            }
+        );
+
+        TestServiceRegister::registerService(
+            SaveAffiliateSettingsHandler::class,
+            static function () {
+                return new SaveAffiliateSettingsHandler(
+                    TestServiceRegister::getService(AffiliateSettingsService::class)
+                );
+            }
+        );
+
+        TestServiceRegister::registerService(
             GetBannerSettingsHandler::class,
             static function () {
                 return new GetBannerSettingsHandler(
@@ -978,6 +1000,16 @@ class BaseTestCase extends TestCase
         );
 
         TopicHandlerRegistry::register(
+            Topics::GET_AFFILIATE_SETTINGS,
+            GetAffiliateSettingsHandler::class
+        );
+
+        TopicHandlerRegistry::register(
+            Topics::SAVE_AFFILIATE_SETTINGS,
+            SaveAffiliateSettingsHandler::class
+        );
+
+        TopicHandlerRegistry::register(
             Topics::GET_BANNER_SETTINGS,
             GetBannerSettingsHandler::class
         );
@@ -1045,6 +1077,7 @@ class BaseTestCase extends TestCase
         TestRepositoryRegistry::registerRepository(Credentials::getClassName(), MemoryRepository::getClassName());
         TestRepositoryRegistry::registerRepository(Deployment::getClassName(), MemoryRepository::getClassName());
         TestRepositoryRegistry::registerRepository(AdvancedSettings::getClassName(), MemoryRepository::getClassName());
+        TestRepositoryRegistry::registerRepository(AffiliateSettings::getClassName(), MemoryRepository::getClassName());
     }
 
     /**

--- a/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsRepository.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsRepository.php
@@ -32,12 +32,4 @@ class MockAffiliateSettingsRepository implements AffiliateSettingsRepositoryInte
     {
         $this->settings = $settings;
     }
-
-    /**
-     * @return void
-     */
-    public function deleteAffiliateSettings(): void
-    {
-        $this->settings = null;
-    }
 }

--- a/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsRepository.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\Common\MockComponents;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
+
+/**
+ * Class MockAffiliateSettingsRepository.
+ *
+ * @package Common\MockComponents
+ */
+class MockAffiliateSettingsRepository implements AffiliateSettingsRepositoryInterface
+{
+    /**
+     * @var ?AffiliateSettings $settings
+     */
+    private $settings;
+
+    /**
+     * @inheritDoc
+     */
+    public function getAffiliateSettings(): ?AffiliateSettings
+    {
+        return $this->settings;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setAffiliateSettings(AffiliateSettings $settings): void
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * @return void
+     */
+    public function deleteAffiliateSettings(): void
+    {
+        $this->settings = null;
+    }
+}

--- a/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsService.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsService.php
@@ -18,11 +18,11 @@ class MockAffiliateSettingsService extends AffiliateSettingsService
     private $affiliateSettings;
 
     /**
-     * @return ?AffiliateSettings
+     * @return AffiliateSettings
      */
-    public function getAffiliateSettings(): ?AffiliateSettings
+    public function getAffiliateSettings(): AffiliateSettings
     {
-        return $this->affiliateSettings;
+        return $this->affiliateSettings ?? new AffiliateSettings(false, '', '');
     }
 
     /**

--- a/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsService.php
+++ b/tests/BusinessLogic/Common/MockComponents/MockAffiliateSettingsService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\Common\MockComponents;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
+
+/**
+ * Class MockAffiliateSettingsService.
+ *
+ * @package Common\MockComponents
+ */
+class MockAffiliateSettingsService extends AffiliateSettingsService
+{
+    /**
+     * @var ?AffiliateSettings $affiliateSettings
+     */
+    private $affiliateSettings;
+
+    /**
+     * @return ?AffiliateSettings
+     */
+    public function getAffiliateSettings(): ?AffiliateSettings
+    {
+        return $this->affiliateSettings;
+    }
+
+    /**
+     * @param ?AffiliateSettings $affiliateSettings
+     *
+     * @return void
+     */
+    public function setAffiliateSettings(?AffiliateSettings $affiliateSettings): void
+    {
+        $this->affiliateSettings = $affiliateSettings;
+    }
+}

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -1884,6 +1884,34 @@ class ConfigurationWebhookAPITest extends BaseTestCase
      * @throws InvalidEnvironmentException
      * @throws EmptyCategoryParameterException
      */
+    public function testSaveAffiliateSettingsEnabledWithoutCredentialsIsCoercedToDisabled(): void
+    {
+        //Arrange
+        $this->affiliateSettingsService->setAffiliateSettings(null);
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-affiliate-settings",
+                "isEnabled" => true,
+                "offerId" => "",
+                "securityToken" => ""
+            ]
+        );
+
+        //Assert: enabled with no credentials is unusable, so it persists as disabled.
+        self::assertTrue($response->isSuccessful());
+        $saved = $this->affiliateSettingsService->getAffiliateSettings();
+        self::assertFalse($saved->isEnabled());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     * @throws EmptyCategoryParameterException
+     */
     public function testGetAffiliateSettingsResponse(): void
     {
         //Arrange
@@ -1898,13 +1926,9 @@ class ConfigurationWebhookAPITest extends BaseTestCase
             ]
         );
 
-        //Assert
+        //Assert: GET returns only the enabled state, never the offer id or security token.
         self::assertTrue($response->isSuccessful());
-        self::assertEquals([
-            'isEnabled' => true,
-            'offerId' => '1234',
-            'securityToken' => 'abc123token'
-        ], $response->toArray());
+        self::assertEquals(['isEnabled' => true], $response->toArray());
     }
 
     /**
@@ -1926,9 +1950,9 @@ class ConfigurationWebhookAPITest extends BaseTestCase
             ]
         );
 
-        //Assert
+        //Assert: no stored settings reads as a deterministic enabled=false.
         self::assertTrue($response->isSuccessful());
-        self::assertEmpty($response->toArray());
+        self::assertEquals(['isEnabled' => false], $response->toArray());
     }
 
     /**

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -398,7 +398,8 @@ class ConfigurationWebhookAPITest extends BaseTestCase
             new MockConnectionProxy(),
             new MockCredentialsRepository(),
             new MockCountryConfigurationRepository(),
-            new MockPaymentMethodRepository()
+            new MockPaymentMethodRepository(),
+            $this->affiliateSettingsService
         );
 
         TestServiceRegister::registerService(CredentialsService::class, function () {

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -6,6 +6,8 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\ConfigurationWebhookAPI;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\BannerSettings\BannerSettingsResponse;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Models\AdvancedSettings;
 use SeQura\Core\BusinessLogic\Domain\AdvancedSettings\Services\AdvancedSettingsService;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Exceptions\InvalidBannerUrlException;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Models\Banner;
 use SeQura\Core\BusinessLogic\Domain\BannerSettings\Models\BannerSettings;
@@ -61,6 +63,8 @@ use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
 use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAdvancedSettingsRepository;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAdvancedSettingsService;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsRepository;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockBannerService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockBannerSettingsRepository;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockBannerSettingsService;
@@ -185,6 +189,11 @@ class ConfigurationWebhookAPITest extends BaseTestCase
      * @var AdvancedSettingsService $advancedSettingsService
      */
     private $advancedSettingsService;
+
+    /**
+     * @var AffiliateSettingsService $affiliateSettingsService
+     */
+    private $affiliateSettingsService;
 
     /**
      * @var MockBannerService $bannerService
@@ -363,6 +372,14 @@ class ConfigurationWebhookAPITest extends BaseTestCase
 
         TestServiceRegister::registerService(AdvancedSettingsService::class, function () {
             return $this->advancedSettingsService;
+        });
+
+        $this->affiliateSettingsService = new MockAffiliateSettingsService(
+            new MockAffiliateSettingsRepository()
+        );
+
+        TestServiceRegister::registerService(AffiliateSettingsService::class, function () {
+            return $this->affiliateSettingsService;
         });
 
         $this->bannerService = new MockBannerService();
@@ -1821,6 +1838,91 @@ class ConfigurationWebhookAPITest extends BaseTestCase
             $this->signature,
             [
                 "topic" => "get-advanced-settings"
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEmpty($response->toArray());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     * @throws EmptyCategoryParameterException
+     */
+    public function testSaveAffiliateSettingsResponse(): void
+    {
+        //Arrange
+        $this->affiliateSettingsService->setAffiliateSettings(null);
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-affiliate-settings",
+                "isEnabled" => true,
+                "offerId" => "1234",
+                "securityToken" => "abc123token"
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEmpty($response->toArray());
+        $saved = $this->affiliateSettingsService->getAffiliateSettings();
+        self::assertNotNull($saved);
+        self::assertTrue($saved->isEnabled());
+        self::assertEquals("1234", $saved->getOfferId());
+        self::assertEquals("abc123token", $saved->getSecurityToken());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     * @throws EmptyCategoryParameterException
+     */
+    public function testGetAffiliateSettingsResponse(): void
+    {
+        //Arrange
+        $affiliateSettings = new AffiliateSettings(true, "1234", "abc123token");
+        $this->affiliateSettingsService->setAffiliateSettings($affiliateSettings);
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "get-affiliate-settings"
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEquals([
+            'isEnabled' => true,
+            'offerId' => '1234',
+            'securityToken' => 'abc123token'
+        ], $response->toArray());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     * @throws EmptyCategoryParameterException
+     */
+    public function testGetAffiliateSettingsResponseNoAffiliateSettings(): void
+    {
+        //Arrange
+        $this->affiliateSettingsService->setAffiliateSettings(null);
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "get-affiliate-settings"
             ]
         );
 

--- a/tests/BusinessLogic/DataAccess/Affiliate/Entities/AffiliateSettingsEntityTest.php
+++ b/tests/BusinessLogic/DataAccess/Affiliate/Entities/AffiliateSettingsEntityTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\DataAccess\Affiliate\Entities;
+
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings;
+use SeQura\Core\Tests\Infrastructure\ORM\Entity\GenericEntityTest;
+
+/**
+ * Class AffiliateSettingsEntityTest.
+ *
+ * @package DataAccess\Affiliate\Entities
+ */
+class AffiliateSettingsEntityTest extends GenericEntityTest
+{
+    /**
+     * @inheritDoc
+     */
+    public function getEntityClass(): string
+    {
+        return AffiliateSettings::getClassName();
+    }
+}

--- a/tests/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepositoryTest.php
+++ b/tests/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepositoryTest.php
@@ -168,30 +168,4 @@ class AffiliateSettingsRepositoryTest extends BaseTestCase
         self::assertCount(1, $savedEntity);
         self::assertEquals($affiliateSettings2, $savedEntity[0]->getAffiliateSettings());
     }
-
-    /**
-     * @return void
-     *
-     * @throws Exception
-     */
-    public function testDeleteAffiliateSettings(): void
-    {
-        // arrange
-        $affiliateSettings1 = new AffiliateSettings(true, '1234', 'abc123token');
-        $entity = new AffiliateSettingsEntity();
-
-        $entity->setAffiliateSettings($affiliateSettings1);
-        $entity->setStoreId('1');
-        $this->repository->save($entity);
-
-        // act
-        StoreContext::doWithStore(
-            '1',
-            [$this->affiliateSettingsRepository, 'deleteAffiliateSettings']
-        );
-
-        // assert
-        $entities = $this->repository->select();
-        self::assertCount(0, $entities);
-    }
 }

--- a/tests/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepositoryTest.php
+++ b/tests/BusinessLogic/DataAccess/Affiliate/Repositories/AffiliateSettingsRepositoryTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\DataAccess\Affiliate\Repositories;
+
+use Exception;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Entities\AffiliateSettings as AffiliateSettingsEntity;
+use SeQura\Core\BusinessLogic\DataAccess\Affiliate\Repositories\AffiliateSettingsRepository;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\RepositoryContracts\AffiliateSettingsRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
+use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryNotRegisteredException;
+use SeQura\Core\Infrastructure\ORM\Interfaces\RepositoryInterface;
+use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
+use SeQura\Core\Tests\Infrastructure\Common\TestComponents\ORM\TestRepositoryRegistry;
+use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
+
+/**
+ * Class AffiliateSettingsRepositoryTest.
+ *
+ * @package DataAccess\Affiliate\Repositories
+ */
+class AffiliateSettingsRepositoryTest extends BaseTestCase
+{
+    /** @var RepositoryInterface */
+    private $repository;
+
+    /** @var AffiliateSettingsRepositoryInterface */
+    private $affiliateSettingsRepository;
+
+    /**
+     * @return void
+     *
+     * @throws RepositoryClassException
+     * @throws RepositoryNotRegisteredException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = TestRepositoryRegistry::getRepository(AffiliateSettingsEntity::getClassName());
+        $this->affiliateSettingsRepository = new AffiliateSettingsRepository(
+            TestRepositoryRegistry::getRepository(AffiliateSettingsEntity::getClassName()),
+            StoreContext::getInstance()
+        );
+
+        TestServiceRegister::registerService(AffiliateSettingsRepositoryInterface::class, function () {
+            return $this->affiliateSettingsRepository;
+        });
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testGetSettingsNoSettings(): void
+    {
+        // act
+        $result = StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'getAffiliateSettings']
+        );
+
+        // assert
+        self::assertEmpty($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetAffiliateSettings(): void
+    {
+        // arrange
+        $affiliateSettings = new AffiliateSettings(true, '1234', 'abc123token');
+        $entity = new AffiliateSettingsEntity();
+
+        $entity->setAffiliateSettings($affiliateSettings);
+        $entity->setStoreId('1');
+        $this->repository->save($entity);
+
+        // act
+        $result = StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'getAffiliateSettings']
+        );
+
+        // assert
+        self::assertEquals($affiliateSettings, $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetSettingsDifferentStores(): void
+    {
+        // arrange
+        $affiliateSettings1 = new AffiliateSettings(true, '1234', 'tokenone');
+        $entity = new AffiliateSettingsEntity();
+        $entity->setAffiliateSettings($affiliateSettings1);
+        $entity->setStoreId('1');
+        $this->repository->save($entity);
+
+        $affiliateSettings2 = new AffiliateSettings(false, '5678', 'tokentwo');
+        $entity = new AffiliateSettingsEntity();
+        $entity->setAffiliateSettings($affiliateSettings2);
+        $entity->setStoreId('2');
+        $this->repository->save($entity);
+
+        // act
+        $result1 = StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'getAffiliateSettings']
+        );
+        $result2 = StoreContext::doWithStore(
+            '2',
+            [$this->affiliateSettingsRepository, 'getAffiliateSettings']
+        );
+
+        // assert
+        self::assertEquals($affiliateSettings1, $result1);
+        self::assertEquals($affiliateSettings2, $result2);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSetAffiliateSettings(): void
+    {
+        // arrange
+        $affiliateSettings = new AffiliateSettings(true, '1234', 'abc123token');
+
+        // act
+        StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'setAffiliateSettings'],
+            [$affiliateSettings]
+        );
+
+        // assert
+        $savedEntity = $this->repository->select();
+        self::assertEquals($affiliateSettings, $savedEntity[0]->getAffiliateSettings());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUpdateAffiliateSettings(): void
+    {
+        // arrange
+        $affiliateSettings1 = new AffiliateSettings(true, '1234', 'tokenone');
+        $affiliateSettings2 = new AffiliateSettings(false, '5678', 'tokentwo');
+
+        // act
+        StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'setAffiliateSettings'],
+            [$affiliateSettings1]
+        );
+        StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'setAffiliateSettings'],
+            [$affiliateSettings2]
+        );
+
+        // assert
+        $savedEntity = $this->repository->select();
+        self::assertCount(1, $savedEntity);
+        self::assertEquals($affiliateSettings2, $savedEntity[0]->getAffiliateSettings());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testDeleteAffiliateSettings(): void
+    {
+        // arrange
+        $affiliateSettings1 = new AffiliateSettings(true, '1234', 'abc123token');
+        $entity = new AffiliateSettingsEntity();
+
+        $entity->setAffiliateSettings($affiliateSettings1);
+        $entity->setStoreId('1');
+        $this->repository->save($entity);
+
+        // act
+        StoreContext::doWithStore(
+            '1',
+            [$this->affiliateSettingsRepository, 'deleteAffiliateSettings']
+        );
+
+        // assert
+        $entities = $this->repository->select();
+        self::assertCount(0, $entities);
+    }
+}

--- a/tests/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsServiceTest.php
+++ b/tests/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsServiceTest.php
@@ -48,8 +48,11 @@ class AffiliateSettingsServiceTest extends BaseTestCase
         //Act
         $result = $this->service->getAffiliateSettings();
 
-        //Assert
-        self::assertNull($result);
+        //Assert: absent settings yield a safe disabled default, never null.
+        self::assertNotNull($result);
+        self::assertFalse($result->isEnabled());
+        self::assertSame('', $result->getOfferId());
+        self::assertSame('', $result->getSecurityToken());
     }
 
     /**

--- a/tests/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsServiceTest.php
+++ b/tests/BusinessLogic/Domain/Affiliate/Services/AffiliateSettingsServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\Domain\Affiliate\Services;
+
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Models\AffiliateSettings;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
+use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
+use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsRepository;
+
+/**
+ * Class AffiliateSettingsServiceTest.
+ *
+ * @package Domain\Affiliate\Services
+ */
+class AffiliateSettingsServiceTest extends BaseTestCase
+{
+    /**
+     * @var AffiliateSettingsService $service
+     */
+    private $service;
+
+    /**
+     * @var MockAffiliateSettingsRepository $repository
+     */
+    private $repository;
+
+    /**
+     * @return void
+     *
+     * @throws RepositoryClassException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new MockAffiliateSettingsRepository();
+        $this->service = new AffiliateSettingsService($this->repository);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAffiliateSettingsNoSettings(): void
+    {
+        //Arrange
+
+        //Act
+        $result = $this->service->getAffiliateSettings();
+
+        //Assert
+        self::assertNull($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAffiliateSettings(): void
+    {
+        //Arrange
+        $affiliateSettings = new AffiliateSettings(true, '1234', 'abc123token');
+        $this->repository->setAffiliateSettings($affiliateSettings);
+
+        //Act
+        $result = $this->service->getAffiliateSettings();
+
+        //Assert
+        self::assertNotNull($result);
+        self::assertTrue($result->isEnabled());
+        self::assertEquals('1234', $result->getOfferId());
+        self::assertEquals('abc123token', $result->getSecurityToken());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetAffiliateSettingsNoSettingsInDB(): void
+    {
+        //Arrange
+        $affiliateSettings = new AffiliateSettings(true, '1234', 'abc123token');
+
+        //Act
+        $this->service->setAffiliateSettings($affiliateSettings);
+
+        //Assert
+        $result = $this->repository->getAffiliateSettings();
+        self::assertNotNull($result);
+        self::assertTrue($result->isEnabled());
+        self::assertEquals('1234', $result->getOfferId());
+        self::assertEquals('abc123token', $result->getSecurityToken());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetAffiliateSettingsSettingsChanged(): void
+    {
+        //Arrange
+        $affiliateSettings = new AffiliateSettings(true, '1234', 'abc123token');
+        $this->repository->setAffiliateSettings(new AffiliateSettings(false, '9999', 'oldtoken'));
+
+        //Act
+        $this->service->setAffiliateSettings($affiliateSettings);
+
+        //Assert
+        $result = $this->repository->getAffiliateSettings();
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isEnabled());
+        self::assertEquals('1234', $result->getOfferId());
+        self::assertEquals('abc123token', $result->getSecurityToken());
+    }
+}

--- a/tests/BusinessLogic/Domain/Connection/Services/ConnectionServiceTest.php
+++ b/tests/BusinessLogic/Domain/Connection/Services/ConnectionServiceTest.php
@@ -10,6 +10,7 @@ use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\BadMerchantIdExceptio
 use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\InvalidEnvironmentException;
 use SeQura\Core\BusinessLogic\Domain\Connection\Exceptions\WrongCredentialsException;
 use SeQura\Core\BusinessLogic\Domain\Connection\Models\AuthorizationCredentials;
+use SeQura\Core\BusinessLogic\Domain\Affiliate\Services\AffiliateSettingsService;
 use SeQura\Core\BusinessLogic\Domain\Connection\Models\Credentials;
 use SeQura\Core\BusinessLogic\Domain\Connection\ProxyContracts\ConnectionProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\Connection\RepositoryContracts\ConnectionDataRepositoryInterface;
@@ -293,6 +294,45 @@ class ConnectionServiceTest extends BaseTestCase
         $savedCredentials = $this->mockCredentialsRepository->getCredentials();
 
         self::assertEquals($credentials, $savedCredentials);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws BadMerchantIdException
+     * @throws CapabilitiesEmptyException
+     * @throws HttpRequestException
+     * @throws InvalidEnvironmentException
+     * @throws PaymentMethodNotFoundException
+     * @throws WrongCredentialsException
+     */
+    public function testConnectAffiliateSettingsSaved(): void
+    {
+        //Arrange
+        $connectionData = new DomainConnectionData(
+            BaseProxy::TEST_MODE,
+            'test_merchant',
+            'sequra',
+            new AuthorizationCredentials('test_username', 'test_password')
+        );
+        $this->mockConnectionProxy->setMockCredentials([
+            new Credentials('logeecom1', 'PT', 'EUR', 'assetsKey1', [
+                'affiliate' => [
+                    'enabled' => true,
+                    'offer_id' => 'mock-affiliate-offer',
+                    'security_token' => 'mock-affiliate-security-token',
+                ],
+            ], 'sequra'),
+        ]);
+
+        //Act
+        $this->connectionService->connect([$connectionData]);
+
+        //Assert: the connect-time affiliate block is persisted via the affiliate settings service.
+        $affiliateSettings = TestServiceRegister::getService(AffiliateSettingsService::class)->getAffiliateSettings();
+        self::assertTrue($affiliateSettings->isEnabled());
+        self::assertEquals('mock-affiliate-offer', $affiliateSettings->getOfferId());
+        self::assertEquals('mock-affiliate-security-token', $affiliateSettings->getSecurityToken());
     }
 
     /**

--- a/tests/BusinessLogic/Domain/Migration/Tasks/StoreIntegrationMigrateTaskTest.php
+++ b/tests/BusinessLogic/Domain/Migration/Tasks/StoreIntegrationMigrateTaskTest.php
@@ -13,6 +13,8 @@ use SeQura\Core\BusinessLogic\Domain\Stores\Services\StoreService;
 use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
 use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryNotRegisteredException;
 use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsRepository;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionDataRepository;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionProxy;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionService;
@@ -88,7 +90,8 @@ class StoreIntegrationMigrateTaskTest extends BaseTestCase
                 new MockConnectionProxy(),
                 new MockCredentialsRepository(),
                 new MockCountryConfigurationRepository(),
-                new MockPaymentMethodRepository()
+                new MockPaymentMethodRepository(),
+                new MockAffiliateSettingsService(new MockAffiliateSettingsRepository())
             ),
             $this->storeIntegrationService
         );

--- a/tests/BusinessLogic/Domain/Order/Builders/MerchantOrderRequestBuilderTest.php
+++ b/tests/BusinessLogic/Domain/Order/Builders/MerchantOrderRequestBuilderTest.php
@@ -20,6 +20,8 @@ use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Merchant;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService;
 use SeQura\Core\Infrastructure\ORM\Exceptions\RepositoryClassException;
 use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsRepository;
+use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockAffiliateSettingsService;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionDataRepository;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionProxy;
 use SeQura\Core\Tests\BusinessLogic\Common\MockComponents\MockConnectionService;
@@ -70,7 +72,8 @@ class MerchantOrderRequestBuilderTest extends BaseTestCase
             new MockConnectionProxy(),
             new MockCredentialsRepository(),
             new MockCountryConfigurationRepository(),
-            new MockPaymentMethodRepository()
+            new MockPaymentMethodRepository(),
+            new MockAffiliateSettingsService(new MockAffiliateSettingsRepository())
         );
         $this->connectionService = new MockConnectionService(
             new MockConnectionDataRepository(),


### PR DESCRIPTION
### What is the goal?

Add a reusable **"affiliate" configuration topic** to integration-core's `ConfigurationWebhookAPI`, so every seQura payment plugin can receive its affiliate (Prime) configuration — **enabled, Offer ID, Security Token** — through the existing signed config-push mechanism, with **no manual UI**. Part of the autoconfiguration-first approach (Option A) of epic QRD-7897.

### References
* **Issue:** [QRD-7899](https://sequra.atlassian.net/browse/QRD-7899) (epic [QRD-7897](https://sequra.atlassian.net/browse/QRD-7897))
* **Related pull-requests:** `woocommerce-sequra` #163 (consumer plugin, [QRD-7898](https://sequra.atlassian.net/browse/QRD-7898))

### How is it being implemented?

Mirrors the simplest existing topic, **AdvancedSettings**, as an end-to-end vertical slice:

- **Domain** (`Domain/Affiliate`): `AffiliateSettings` model (`isEnabled`, `offerId`, `securityToken`), `AffiliateSettingsRepositoryInterface`, and `AffiliateSettingsService` — the reusable read service plugins use to obtain the resolved config.
- **DataAccess** (`DataAccess/Affiliate`): `AffiliateSettings` entity (indexed by `storeId`) + repository.
- **ConfigurationWebhookAPI**: `SaveAffiliateSettingsRequest`, `AffiliateSettingsResponse`, and `Get`/`Save` topic handlers.
- **Wiring**: `get-affiliate-settings` / `save-affiliate-settings` added to the `Topics` enum (and `ALL_TOPICS`), and registered in `BootstrapComponent` (repository, service, topics, handler services).

Signature validation and the topic dispatch are reused as-is; no new signing logic is introduced.

### Caveats

- The exact payload field names (`isEnabled` / `offerId` / `securityToken`) are the **proposed** config contract and may be adjusted once the cross-team contract is confirmed (decision D5 in the epic); the structure won't change.
- Table creation is the responsibility of each **host plugin** (it registers a repository for the new entity, as with the other settings entities). integration-core only registers the entity for tests.

### Does it affect (changes or update) any sensitive data?

The Security Token is a credential-like value. It is persisted per store like the other settings and only delivered through the existing signed config-push. It is not logged.

### How is it tested?

Automatic tests (PHPUnit):
- New `AffiliateSettings` **entity** test, **repository** test (get/set/update/delete + multistore isolation), and **service** test.
- 3 end-to-end cases in `ConfigurationWebhookAPITest`: save persists, get returns the persisted config, get with no settings returns empty.

Full suite: **819 tests OK** (16 new), **0 regressions**. PHPCS (PSR12) clean. PHPStan level 6: no errors.

### How is it going to be deployed?

Standard deployment (library release/tag, consumed by the payment plugins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QRD-7899]: https://sequra.atlassian.net/browse/QRD-7899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QRD-7897]: https://sequra.atlassian.net/browse/QRD-7897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QRD-7898]: https://sequra.atlassian.net/browse/QRD-7898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ