### PR TITLE
Remove deprecated curl_close() calls because they are no-op in PHP >= 8.0

### DIFF
--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -197,7 +197,7 @@ class CurlHttpClient extends HttpClient
      */
     protected function closeCurlSession(): void
     {
-        if (PHP_VERSION_ID < 80000 && is_resource($this->curlSession)) {
+        if (PHP_VERSION_ID < 80000 && \is_resource($this->curlSession)) {
             curl_close($this->curlSession);
         }
         $this->curlSession = null;

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -48,7 +48,7 @@ class CurlHttpClient extends HttpClient
     /**
      * CURL handler.
      *
-     * @var resource
+     * @var resource|null
      */
     protected $curlSession;
 
@@ -114,14 +114,14 @@ class CurlHttpClient extends HttpClient
 
         if ($result === false) {
             $error = curl_errno($this->curlSession) . ' = ' . curl_error($this->curlSession);
-            curl_close($this->curlSession);
+            $this->closeCurlSession();
 
             throw new HttpCommunicationException(
                 'Request ' . $this->curlOptions[CURLOPT_URL] . ' failed. ERROR: ' . $error
             );
         }
 
-        curl_close($this->curlSession);
+        $this->closeCurlSession();
 
         return new HttpResponse($statusCode, $headers, $result);
     }
@@ -149,7 +149,7 @@ class CurlHttpClient extends HttpClient
             Logger::logError('Async process failed. ERROR: ' . $httpError);
         }
 
-        curl_close($this->curlSession);
+        $this->closeCurlSession();
     }
 
     /**
@@ -188,6 +188,19 @@ class CurlHttpClient extends HttpClient
 
         $this->curlSession = curl_init();
         $this->curlOptions = array();
+    }
+
+    /**
+     * Close cURL session.
+     *
+     * @return void
+     */
+    protected function closeCurlSession(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->curlSession);
+        }
+        $this->curlSession = null;
     }
 
     /**

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -114,14 +114,14 @@ class CurlHttpClient extends HttpClient
 
         if ($result === false) {
             $error = curl_errno($this->curlSession) . ' = ' . curl_error($this->curlSession);
-            curl_close($this->curlSession);
+            $this->closeCurlSession();
 
             throw new HttpCommunicationException(
                 'Request ' . $this->curlOptions[CURLOPT_URL] . ' failed. ERROR: ' . $error
             );
         }
 
-        curl_close($this->curlSession);
+        $this->closeCurlSession();
 
         return new HttpResponse($statusCode, $headers, $result);
     }
@@ -149,7 +149,7 @@ class CurlHttpClient extends HttpClient
             Logger::logError('Async process failed. ERROR: ' . $httpError);
         }
 
-        curl_close($this->curlSession);
+        $this->closeCurlSession();
     }
 
     /**
@@ -188,6 +188,19 @@ class CurlHttpClient extends HttpClient
 
         $this->curlSession = curl_init();
         $this->curlOptions = array();
+    }
+
+    /**
+     * Close cURL session.
+     *
+     * @return void
+     */
+    protected function closeCurlSession(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->curlSession);
+        }
+        $this->curlSession = null;
     }
 
     /**

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -48,7 +48,7 @@ class CurlHttpClient extends HttpClient
     /**
      * CURL handler.
      *
-     * @var resource
+     * @var resource|null
      */
     protected $curlSession;
 

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -197,7 +197,7 @@ class CurlHttpClient extends HttpClient
      */
     protected function closeCurlSession(): void
     {
-        if (PHP_VERSION_ID < 80000) {
+        if (PHP_VERSION_ID < 80000 && is_resource($this->curlSession)) {
             curl_close($this->curlSession);
         }
         $this->curlSession = null;


### PR DESCRIPTION
 ### What is the goal?

Fix the task runner wakeup failure on Magento 2.4.9 running PHP 8.5. `curl_close()` is deprecated as of PHP 8.5 ("it has no effect since PHP 8.0"), and Magento's error handler converts the deprecation notice into an exception, so the asynchronous task runner start  in `AsyncProcessStarterService::startRunnerAsynchronously()` failed with:

  > Fail to wakeup task runner. Unexpected error occurred.
  > Deprecated Functionality: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in .../integration-core/src/Infrastructure/Http/CurlHttpClient.php on line 152

The goal is to remove all `curl_close()` usage on PHP >= 8.0 so the plugin works on PHP 8.5, while keeping the library's PHP 7.2 floor intact.

 ### How is it being implemented?

All direct `curl_close($this->curlSession)` calls in `Infrastructure/Http/CurlHttpClient.php` (synchronous success/error paths and the asynchronous path) are replaced with a new `protected closeCurlSession(): void` method that:

  * calls `curl_close()` only on PHP < 8.0, where the handle is still a `resource` and closing it deterministically frees the connection,
  * on PHP >= 8.0 just releases the reference (`$this->curlSession = null`) - the handle is a `CurlHandle` object there and `curl_close()` has been a no-op since 8.0, so dropping the reference closes the session without touching the deprecated function.

The `$curlSession` property docblock is updated to `@var resource|null` accordingly.
Error details (`curl_errno()`/`curl_error()`) are still read before the session is closed.

 ### Opportunistic refactorings

None - the change is limited to the cURL session teardown.

 ### Caveats

* `curl_close()` is intentionally kept for PHP < 8.0 (explicit, deterministic close of the `resource`). The version guard uses `PHP_VERSION_ID < 80000`, matching the version where handles became objects.
* Being `protected`, `closeCurlSession()` is overridable by platform-specific subclasses, like the rest of the client.

### Does it affect (changes or update) any sensitive data?

No. The change only alters how the cURL handle is released. No request/response data, credentials, or configuration handling is touched.

 ### How is it tested?

Automatic tests: full PHPUnit unit test suite executed - all tests pass.
Manual tests: manually tested locally on PHP 7.4 (Magento 2.4.3) and PHP 8.5 (Magento 2.4.9). On 8.5 the previous code triggers the curl_close() deprecation, which Magento's error handler converts into an exception, causing the async process (task runner wakeup) to fail. With this change no such error is raised, and requests (sync and async paths) behave as before on both versions.

 ### How is it going to be deployed?

Standard deployment. This is a Composer library - host platforms pick up the fix by bumping the dependency. No configuration or migration steps.