### PR TITLE
Add SVEA deployment support to the WIX integration

### DIFF
--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -19,6 +19,7 @@ use SeQura\Core\BusinessLogic\CheckoutAPI\Banners\BannerCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Checkout\Controller\CheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\ExpressCheckout\Controller\ExpressCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\CachedPaymentMethodsController;
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\PaymentMethodsCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PromotionalWidgets\PromotionalWidgetsCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Solicitation\Controller\SolicitationController;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Controller\ConfigurationWebhookController;
@@ -903,6 +904,15 @@ class BootstrapComponent extends BaseBootstrapComponent
         );
 
         ServiceRegister::registerService(
+            PaymentMethodsCheckoutController::class,
+            static function () {
+                return new PaymentMethodsCheckoutController(
+                    ServiceRegister::getService(OrderService::class)
+                );
+            }
+        );
+
+        ServiceRegister::registerService(
             PromotionalWidgetsCheckoutController::class,
             static function () {
                 return new PromotionalWidgetsCheckoutController(
@@ -916,7 +926,8 @@ class BootstrapComponent extends BaseBootstrapComponent
             CheckoutController::class,
             static function () {
                 return new CheckoutController(
-                    ServiceRegister::getService(CheckoutInitializationService::class)
+                    ServiceRegister::getService(CheckoutInitializationService::class),
+                    ServiceRegister::getService(OrderService::class)
                 );
             }
         );

--- a/src/BusinessLogic/BootstrapComponent.php
+++ b/src/BusinessLogic/BootstrapComponent.php
@@ -926,8 +926,7 @@ class BootstrapComponent extends BaseBootstrapComponent
             CheckoutController::class,
             static function () {
                 return new CheckoutController(
-                    ServiceRegister::getService(CheckoutInitializationService::class),
-                    ServiceRegister::getService(OrderService::class)
+                    ServiceRegister::getService(CheckoutInitializationService::class)
                 );
             }
         );

--- a/src/BusinessLogic/CheckoutAPI/CheckoutAPI.php
+++ b/src/BusinessLogic/CheckoutAPI/CheckoutAPI.php
@@ -10,6 +10,7 @@ use SeQura\Core\BusinessLogic\CheckoutAPI\Checkout\Controller\CheckoutController
 use SeQura\Core\BusinessLogic\CheckoutAPI\ExpressCheckout\Controller\ExpressCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Banners\BannerCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\CachedPaymentMethodsController;
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\PaymentMethodsCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PromotionalWidgets\PromotionalWidgetsCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Solicitation\Controller\SolicitationController;
 
@@ -58,6 +59,19 @@ class CheckoutAPI
             ::run(new ErrorHandlingAspect())
             ->andRun(new StoreContextAspect($storeId))
             ->beforeEachMethodOfService(CachedPaymentMethodsController::class);
+    }
+
+    /**
+     * @param string $storeId
+     *
+     * @return object
+     */
+    public function paymentMethods(string $storeId): object
+    {
+        return Aspects
+            ::run(new ErrorHandlingAspect())
+            ->andRun(new StoreContextAspect($storeId))
+            ->beforeEachMethodOfService(PaymentMethodsCheckoutController::class);
     }
 
     /**

--- a/src/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutController.php
+++ b/src/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutController.php
@@ -4,6 +4,7 @@ namespace SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods;
 
 use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Requests\PaymentMethodsInCategoriesRequest;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Responses\PaymentMethodsInCategoriesResponse;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\OrderNotFoundException;
 use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
 use SeQura\Core\Infrastructure\Http\Exceptions\HttpRequestException;
 
@@ -38,15 +39,13 @@ class PaymentMethodsCheckoutController
      * @return PaymentMethodsInCategoriesResponse
      *
      * @throws HttpRequestException
+     * @throws OrderNotFoundException
      */
     public function getPaymentMethodsInCategories(
         PaymentMethodsInCategoriesRequest $request
     ): PaymentMethodsInCategoriesResponse {
         return new PaymentMethodsInCategoriesResponse(
-            $this->orderService->getAvailablePaymentMethodsInCategories(
-                $request->getOrderRef(),
-                $request->getMerchantId()
-            )
+            $this->orderService->getAvailablePaymentMethodsInCategories($request->getOrderRef())
         );
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutController.php
+++ b/src/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods;
+
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Requests\PaymentMethodsInCategoriesRequest;
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Responses\PaymentMethodsInCategoriesResponse;
+use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
+use SeQura\Core\Infrastructure\Http\Exceptions\HttpRequestException;
+
+/**
+ * Class PaymentMethodsCheckoutController.
+ *
+ * Storefront endpoint returning the payment methods of an already solicited order. It depends on OrderService
+ * alone, so integrations that solicit orders without configuring the checkout library can use it.
+ *
+ * @package SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods
+ */
+class PaymentMethodsCheckoutController
+{
+    /**
+     * @var OrderService
+     */
+    protected $orderService;
+
+    /**
+     * @param OrderService $orderService
+     */
+    public function __construct(OrderService $orderService)
+    {
+        $this->orderService = $orderService;
+    }
+
+    /**
+     * Returns the payment methods available for a solicited order, grouped in the categories SeQura returns them in.
+     *
+     * @param PaymentMethodsInCategoriesRequest $request
+     *
+     * @return PaymentMethodsInCategoriesResponse
+     *
+     * @throws HttpRequestException
+     */
+    public function getPaymentMethodsInCategories(
+        PaymentMethodsInCategoriesRequest $request
+    ): PaymentMethodsInCategoriesResponse {
+        return new PaymentMethodsInCategoriesResponse(
+            $this->orderService->getAvailablePaymentMethodsInCategories(
+                $request->getOrderRef(),
+                $request->getMerchantId()
+            )
+        );
+    }
+}

--- a/src/BusinessLogic/CheckoutAPI/PaymentMethods/Requests/PaymentMethodsInCategoriesRequest.php
+++ b/src/BusinessLogic/CheckoutAPI/PaymentMethods/Requests/PaymentMethodsInCategoriesRequest.php
@@ -13,19 +13,13 @@ class PaymentMethodsInCategoriesRequest
      * @var string
      */
     protected $orderRef;
-    /**
-     * @var string
-     */
-    protected $merchantId;
 
     /**
      * @param string $orderRef Reference of the solicited order.
-     * @param string $merchantId Merchant the order was solicited for.
      */
-    public function __construct(string $orderRef, string $merchantId)
+    public function __construct(string $orderRef)
     {
         $this->orderRef = $orderRef;
-        $this->merchantId = $merchantId;
     }
 
     /**
@@ -34,13 +28,5 @@ class PaymentMethodsInCategoriesRequest
     public function getOrderRef(): string
     {
         return $this->orderRef;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMerchantId(): string
-    {
-        return $this->merchantId;
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/PaymentMethods/Requests/PaymentMethodsInCategoriesRequest.php
+++ b/src/BusinessLogic/CheckoutAPI/PaymentMethods/Requests/PaymentMethodsInCategoriesRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Requests;
+
+/**
+ * Class PaymentMethodsInCategoriesRequest.
+ *
+ * @package SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Requests
+ */
+class PaymentMethodsInCategoriesRequest
+{
+    /**
+     * @var string
+     */
+    protected $orderRef;
+    /**
+     * @var string
+     */
+    protected $merchantId;
+
+    /**
+     * @param string $orderRef Reference of the solicited order.
+     * @param string $merchantId Merchant the order was solicited for.
+     */
+    public function __construct(string $orderRef, string $merchantId)
+    {
+        $this->orderRef = $orderRef;
+        $this->merchantId = $merchantId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderRef(): string
+    {
+        return $this->orderRef;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMerchantId(): string
+    {
+        return $this->merchantId;
+    }
+}

--- a/src/BusinessLogic/CheckoutAPI/PaymentMethods/Responses/PaymentMethodsInCategoriesResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/PaymentMethods/Responses/PaymentMethodsInCategoriesResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Responses;
+
+use SeQura\Core\BusinessLogic\AdminAPI\Response\Response;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraPaymentMethod;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraPaymentMethodCategory;
+
+/**
+ * Class PaymentMethodsInCategoriesResponse.
+ *
+ * @package SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Responses
+ */
+class PaymentMethodsInCategoriesResponse extends Response
+{
+    /**
+     * @var SeQuraPaymentMethodCategory[]
+     */
+    protected $paymentMethodCategories;
+
+    /**
+     * @param SeQuraPaymentMethodCategory[] $paymentMethodCategories
+     */
+    public function __construct(array $paymentMethodCategories)
+    {
+        $this->paymentMethodCategories = $paymentMethodCategories;
+    }
+
+    /**
+     * @return SeQuraPaymentMethodCategory[]
+     */
+    public function getPaymentMethodCategories(): array
+    {
+        return $this->paymentMethodCategories;
+    }
+
+    /**
+     * Determines whether at least one category offers a payment method. Categories with no method are returned
+     * as well, so the presence of categories does not mean the buyer has anything to choose from.
+     *
+     * @return bool
+     */
+    public function hasAvailablePaymentMethods(): bool
+    {
+        foreach ($this->paymentMethodCategories as $category) {
+            if (!empty($category->getMethods())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(): array
+    {
+        $categories = [];
+        foreach ($this->paymentMethodCategories as $category) {
+            $categories[] = [
+                'title' => $category->getTitle(),
+                'description' => $category->getDescription(),
+                'icon' => $category->getIcon(),
+                'methods' => array_map(static function (SeQuraPaymentMethod $paymentMethod) {
+                    return $paymentMethod->toArray();
+                }, $category->getMethods()),
+            ];
+        }
+
+        return $categories;
+    }
+}

--- a/src/BusinessLogic/Domain/Disconnect/Services/DisconnectService.php
+++ b/src/BusinessLogic/Domain/Disconnect/Services/DisconnectService.php
@@ -252,14 +252,16 @@ class DisconnectService
 
         // Removes country configurations connected to the deployment
         $countryConfigurations = $this->countryConfigurationRepository->getCountryConfiguration();
-        $newCountyConfigurations = [];
-        foreach ($countryConfigurations as $countryConfiguration) {
-            if (!\in_array($countryConfiguration->getMerchantId(), $merchantIds, true)) {
-                $newCountyConfigurations[] = $countryConfiguration;
+        if ($countryConfigurations) {
+            $newCountyConfigurations = [];
+            foreach ($countryConfigurations as $countryConfiguration) {
+                if (!\in_array($countryConfiguration->getMerchantId(), $merchantIds, true)) {
+                    $newCountyConfigurations[] = $countryConfiguration;
+                }
             }
-        }
 
-        $this->countryConfigurationRepository->setCountryConfiguration($newCountyConfigurations);
+            $this->countryConfigurationRepository->setCountryConfiguration($newCountyConfigurations);
+        }
 
         // Removes all payment methods connected to the deployment
         foreach ($merchantIds as $merchantId) {

--- a/src/BusinessLogic/Domain/Order/Service/OrderService.php
+++ b/src/BusinessLogic/Domain/Order/Service/OrderService.php
@@ -163,19 +163,22 @@ class OrderService
     }
 
     /**
-     * Gets available payment methods for solicited order in categories.
+     * Gets available payment methods for solicited order in categories. The merchant the order was solicited for
+     * is taken from the stored order, so callers only need its reference.
      *
      * @param string $orderRef
-     * @param string $merchantId
      *
      * @return SeQuraPaymentMethodCategory[]
      *
      * @throws HttpRequestException
+     * @throws OrderNotFoundException
      */
-    public function getAvailablePaymentMethodsInCategories(string $orderRef, string $merchantId): array
+    public function getAvailablePaymentMethodsInCategories(string $orderRef): array
     {
+        $order = $this->getSeQuraOrder($orderRef);
+
         return $this->proxy->getAvailablePaymentMethodsInCategories(
-            new GetAvailablePaymentMethodsRequest($orderRef, $merchantId)
+            new GetAvailablePaymentMethodsRequest($orderRef, (string)$order->getMerchant()->getId())
         );
     }
 
@@ -319,8 +322,7 @@ class OrderService
         $updatedSeQuraOrder->setPaymentMethod(
             $this->getOrderPaymentMethodInfo(
                 $updatedSeQuraOrder->getReference(),
-                $webhook->getProductCode(),
-                (string)$updatedSeQuraOrder->getMerchant()->getId()
+                $webhook->getProductCode()
             )
         );
 
@@ -477,21 +479,17 @@ class OrderService
      *
      * @param string $orderReference
      * @param string $paymentMethodId
-     * @param string $merchantId
      *
      * @return PaymentMethod|null
      *
      * @throws HttpRequestException
+     * @throws OrderNotFoundException
      */
     private function getOrderPaymentMethodInfo(
         string $orderReference,
-        string $paymentMethodId,
-        string $merchantId
+        string $paymentMethodId
     ): ?PaymentMethod {
-        $methodCategories = $this->getAvailablePaymentMethodsInCategories(
-            $orderReference,
-            $merchantId
-        );
+        $methodCategories = $this->getAvailablePaymentMethodsInCategories($orderReference);
 
         foreach ($methodCategories as $category) {
             foreach ($category->getMethods() as $method) {

--- a/tests/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutApiTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/PaymentMethods/PaymentMethodsCheckoutApiTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace SeQura\Core\Tests\BusinessLogic\CheckoutAPI\PaymentMethods;
+
+use DateTime;
+use Exception;
+use SeQura\Core\BusinessLogic\CheckoutAPI\CheckoutAPI;
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\Requests\PaymentMethodsInCategoriesRequest;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\OrderNotFoundException;
+use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraCost;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraPaymentMethod;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraPaymentMethodCategory;
+use SeQura\Core\Infrastructure\Http\Exceptions\HttpRequestException;
+use SeQura\Core\Tests\BusinessLogic\Common\BaseTestCase;
+use SeQura\Core\Tests\Infrastructure\Common\TestServiceRegister;
+
+/**
+ * Class PaymentMethodsCheckoutApiTest.
+ *
+ * @package SeQura\Core\Tests\BusinessLogic\CheckoutAPI\PaymentMethods
+ */
+class PaymentMethodsCheckoutApiTest extends BaseTestCase
+{
+    /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderService = $this->createMock(OrderService::class);
+        TestServiceRegister::registerService(OrderService::class, function () {
+            return $this->orderService;
+        });
+    }
+
+    public function testGetPaymentMethodsInCategoriesReturnsCategories(): void
+    {
+        // Arrange
+        $this->orderService->method('getAvailablePaymentMethodsInCategories')->willReturn([
+            new SeQuraPaymentMethodCategory('Paga Después', 'Paga después', 'pay_later.svg', [
+                $this->paymentMethod('i1', 'Paga Después')
+            ])
+        ]);
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEquals([
+            [
+                'title' => 'Paga Después',
+                'description' => 'Paga después',
+                'icon' => 'pay_later.svg',
+                'methods' => [$this->paymentMethod('i1', 'Paga Después')->toArray()],
+            ]
+        ], $response->toArray());
+    }
+
+    public function testGetPaymentMethodsInCategoriesOnlyNeedsOrderReference(): void
+    {
+        // Arrange
+        $this->orderService->expects(self::once())
+            ->method('getAvailablePaymentMethodsInCategories')
+            ->with('testOrderRef')
+            ->willReturn([]);
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertTrue($response->isSuccessful());
+    }
+
+    public function testGetPaymentMethodsInCategoriesNoCategories(): void
+    {
+        // Arrange
+        $this->orderService->method('getAvailablePaymentMethodsInCategories')->willReturn([]);
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEmpty($response->toArray());
+        self::assertFalse($response->hasAvailablePaymentMethods());
+    }
+
+    public function testGetPaymentMethodsInCategoriesCategoryWithoutMethods(): void
+    {
+        // Arrange
+        $this->orderService->method('getAvailablePaymentMethodsInCategories')->willReturn([
+            new SeQuraPaymentMethodCategory('Paga Después', 'Paga después', null, [])
+        ]);
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertNotEmpty($response->toArray());
+        self::assertFalse($response->hasAvailablePaymentMethods());
+    }
+
+    public function testGetPaymentMethodsInCategoriesOrderNotFound(): void
+    {
+        // Arrange
+        $this->orderService->method('getAvailablePaymentMethodsInCategories')
+            ->willThrowException(new OrderNotFoundException('SeQura order with reference testOrderRef is not found.'));
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertFalse($response->isSuccessful());
+    }
+
+    public function testGetPaymentMethodsInCategoriesApiFailure(): void
+    {
+        // Arrange
+        $this->orderService->method('getAvailablePaymentMethodsInCategories')
+            ->willThrowException(new HttpRequestException('Request failed.'));
+
+        // Act
+        $response = CheckoutAPI::get()->paymentMethods('1')
+            ->getPaymentMethodsInCategories(new PaymentMethodsInCategoriesRequest('testOrderRef'));
+
+        // Assert
+        self::assertFalse($response->isSuccessful());
+    }
+
+    /**
+     * @param string $product
+     * @param string $title
+     *
+     * @return SeQuraPaymentMethod
+     *
+     * @throws Exception
+     */
+    private function paymentMethod(string $product, string $title): SeQuraPaymentMethod
+    {
+        return new SeQuraPaymentMethod(
+            $product,
+            $title,
+            $title,
+            'pay_later',
+            new SeQuraCost(0, 0, 0, 0),
+            new DateTime('2000-02-22T21:22:00Z'),
+            new DateTime('2222-02-22T21:22:00Z')
+        );
+    }
+}

--- a/tests/BusinessLogic/CheckoutAPI/Solicitation/MockComponents/MockOrderProxy.php
+++ b/tests/BusinessLogic/CheckoutAPI/Solicitation/MockComponents/MockOrderProxy.php
@@ -47,6 +47,10 @@ class MockOrderProxy implements OrderProxyInterface
      * @var int
      */
     private $getFormCallCount = 0;
+    /**
+     * @var GetAvailablePaymentMethodsRequest|null
+     */
+    private $lastPaymentMethodsInCategoriesRequest;
 
     /**
      * @param ?SeQuraOrder $order
@@ -103,7 +107,17 @@ class MockOrderProxy implements OrderProxyInterface
 
     public function getAvailablePaymentMethodsInCategories(GetAvailablePaymentMethodsRequest $request): array
     {
+        $this->lastPaymentMethodsInCategoriesRequest = $request;
+
         return [];
+    }
+
+    /**
+     * @return GetAvailablePaymentMethodsRequest|null
+     */
+    public function getLastPaymentMethodsInCategoriesRequest(): ?GetAvailablePaymentMethodsRequest
+    {
+        return $this->lastPaymentMethodsInCategoriesRequest;
     }
 
     public function createOrder(CreateOrderRequest $request): SeQuraOrder
@@ -125,6 +139,9 @@ class MockOrderProxy implements OrderProxyInterface
         return true;
     }
 
+    /**
+     * @throws Throwable
+     */
     public function getForm(GetFormRequest $request): SeQuraForm
     {
         $this->getFormCallCount++;

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -513,8 +513,7 @@ class BaseTestCase extends TestCase
             },
             CheckoutController::class => function () {
                 return new CheckoutController(
-                    TestServiceRegister::getService(CheckoutInitializationService::class),
-                    TestServiceRegister::getService(OrderService::class)
+                    TestServiceRegister::getService(CheckoutInitializationService::class)
                 );
             },
             ExpressCheckoutService::class => function () {

--- a/tests/BusinessLogic/Common/BaseTestCase.php
+++ b/tests/BusinessLogic/Common/BaseTestCase.php
@@ -19,6 +19,7 @@ use SeQura\Core\BusinessLogic\CheckoutAPI\Affiliate\AffiliateController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Banners\BannerCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\Checkout\Controller\CheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\CachedPaymentMethodsController;
+use SeQura\Core\BusinessLogic\CheckoutAPI\PaymentMethods\PaymentMethodsCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\ExpressCheckout\Controller\ExpressCheckoutController;
 use SeQura\Core\BusinessLogic\CheckoutAPI\PromotionalWidgets\PromotionalWidgetsCheckoutController;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Controller\ConfigurationWebhookController;
@@ -499,6 +500,11 @@ class BaseTestCase extends TestCase
                     TestServiceRegister::getService(PaymentMethodsService::class)
                 );
             },
+            PaymentMethodsCheckoutController::class => function () {
+                return new PaymentMethodsCheckoutController(
+                    TestServiceRegister::getService(OrderService::class)
+                );
+            },
             PromotionalWidgetsCheckoutController::class => function () {
                 return new PromotionalWidgetsCheckoutController(
                     TestServiceRegister::getService(WidgetSettingsService::class),
@@ -507,7 +513,8 @@ class BaseTestCase extends TestCase
             },
             CheckoutController::class => function () {
                 return new CheckoutController(
-                    TestServiceRegister::getService(CheckoutInitializationService::class)
+                    TestServiceRegister::getService(CheckoutInitializationService::class),
+                    TestServiceRegister::getService(OrderService::class)
                 );
             },
             ExpressCheckoutService::class => function () {

--- a/tests/BusinessLogic/Domain/Order/Services/OrderServiceTest.php
+++ b/tests/BusinessLogic/Domain/Order/Services/OrderServiceTest.php
@@ -10,6 +10,7 @@ use SeQura\Core\BusinessLogic\Domain\Integration\Order\MerchantDataProviderInter
 use SeQura\Core\BusinessLogic\Domain\Integration\Order\OrderCreationInterface;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
 use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\InvalidCartItemsException;
+use SeQura\Core\BusinessLogic\Domain\Order\Exceptions\OrderNotFoundException;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Cart;
 use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\CreateOrderRequest;
@@ -389,8 +390,14 @@ class OrderServiceTest extends BaseTestCase
             __DIR__ . '/../../../Common/ApiResponses/Order/GetPaymentMethodsResponses/SuccessfulResponse.json'
         );
 
+        $order = json_decode(file_get_contents(__DIR__ . '/../../../Common/MockObjects/SeQuraOrder.json'), true);
+        $order['order']['merchant']['id'] = 'testMerchantId';
+        $seQuraOrder = SeQuraOrder::fromArray($order['order']);
+        $seQuraOrder->setReference('testId');
+        $this->orderRepository->setSeQuraOrder($seQuraOrder);
+
         $this->httpClient->setMockResponses([new HttpResponse(200, [], $rawResponseBody)]);
-        $response = $this->orderService->getAvailablePaymentMethodsInCategories('testId', 'testMerchantId');
+        $response = $this->orderService->getAvailablePaymentMethodsInCategories('testId');
         $responseBody = json_decode($rawResponseBody, true);
         $paymentMethodCategories = [];
 
@@ -470,6 +477,62 @@ class OrderServiceTest extends BaseTestCase
                 );
             }
         }
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testGetPaymentMethodsInCategoriesUsesMerchantOfStoredOrder(): void
+    {
+        // Arrange
+        $this->orderProxy = new MockOrderProxy();
+        $this->orderRepository = new MockSeQuraOrderRepository();
+        $this->orderService = new OrderService(
+            $this->orderProxy,
+            $this->orderRepository,
+            $this->merchantOrderBuilder,
+            TestServiceRegister::getService(OrderCreationInterface::class)
+        );
+
+        $order = json_decode(file_get_contents(__DIR__ . '/../../../Common/MockObjects/SeQuraOrder.json'), true);
+        $order['order']['merchant']['id'] = 'merchantOfTheOrder';
+        $seQuraOrder = SeQuraOrder::fromArray($order['order']);
+        $seQuraOrder->setReference('testId');
+        $this->orderRepository->setSeQuraOrder($seQuraOrder);
+
+        // Act
+        $this->orderService->getAvailablePaymentMethodsInCategories('testId');
+
+        // Assert
+        $proxyRequest = $this->orderProxy->getLastPaymentMethodsInCategoriesRequest();
+        self::assertNotNull($proxyRequest);
+        self::assertEquals('testId', $proxyRequest->getOrderId());
+        self::assertEquals('merchantOfTheOrder', $proxyRequest->getMerchantId());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testGetPaymentMethodsInCategoriesForUnknownOrder(): void
+    {
+        // Arrange
+        $this->orderProxy = new MockOrderProxy();
+        $this->orderService = new OrderService(
+            $this->orderProxy,
+            new MockSeQuraOrderRepository(),
+            $this->merchantOrderBuilder,
+            TestServiceRegister::getService(OrderCreationInterface::class)
+        );
+
+        // Assert
+        $this->expectException(OrderNotFoundException::class);
+
+        // Act
+        $this->orderService->getAvailablePaymentMethodsInCategories('unknownOrderRef');
     }
 
     /**

--- a/tests/Infrastructure/ORM/AbstractGenericQueueItemRepositoryTest.php
+++ b/tests/Infrastructure/ORM/AbstractGenericQueueItemRepositoryTest.php
@@ -324,7 +324,7 @@ abstract class AbstractGenericQueueItemRepositoryTest extends TestCase
             $queueItem->setProgressBasePoints($item['progress']);
             $queueItem->setLastExecutionProgressBasePoints($item['lastExecutionProgress']);
             $queueItem->setRetries($item['retries']);
-            $queueItem->setFailureDescription($item['failureDescription']);
+            $queueItem->setFailureDescription($item['failureDescription'] ?? '');
             $queueItem->setSerializedTask(Serializer::serialize($task));
             $queueItem->setCreateTimestamp($item['createTimestamp']);
             $queueItem->setQueueTimestamp($item['queueTimestamp']);


### PR DESCRIPTION
### What is the goal?

- The goal is to expose payment methods for an already solicited order through the Checkout API, without requiring integrations to provide the merchant ID.
- Merchant resolution is now handled internally based on the stored seQura order.

 ### References
* **Issue:** [LIS-116](https://sequra.atlassian.net/browse/LIS-116)

 ### How is it being implemented?

- Added a new payment methods endpoint to the Checkout API
- Added controller and request/response models for retrieving payment methods in categories
- Updated the Order Service to resolve the merchant ID from the stored order
- Registered the new controller in the Core bootstrap
- Added handling to determine whether available payment methods exist
- Adjusted disconnect logic to avoid unnecessary country configuration updates

### How is it tested?
- Unit tests

[LIS-116]: https://sequra.atlassian.net/browse/LIS-116
