### PR TITLE
[PAR-848] Configurable Express Button Styles

### DIFF
--- a/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutController.php
+++ b/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutController.php
@@ -64,15 +64,18 @@ class ExpressCheckoutController
      */
     public function isAvailable(ExpressCheckoutAvailabilityRequest $request): ExpressCheckoutAvailabilityResponse
     {
+        $available = $this->expressCheckoutService->isExpressCheckoutAvailable(
+            $request->getPage(),
+            $request->getCountry(),
+            $request->getCurrency(),
+            $request->getIpAddress(),
+            $request->getProductIds(),
+            $request->getCategoryIds()
+        );
+
         return new ExpressCheckoutAvailabilityResponse(
-            $this->expressCheckoutService->isExpressCheckoutAvailable(
-                $request->getPage(),
-                $request->getCountry(),
-                $request->getCurrency(),
-                $request->getIpAddress(),
-                $request->getProductIds(),
-                $request->getCategoryIds()
-            )
+            $available,
+            $available ? $this->resolveButtonStyle() : null
         );
     }
 
@@ -102,8 +105,13 @@ class ExpressCheckoutController
         );
 
         $countries = $available ? $this->countryConfigurationService->getCountryCodes() : [];
+        $hasCountries = !empty($countries);
 
-        return new GuestExpressCheckoutAvailabilityResponse(!empty($countries), $countries);
+        return new GuestExpressCheckoutAvailabilityResponse(
+            $hasCountries,
+            $countries,
+            $hasCountries ? $this->resolveButtonStyle() : null
+        );
     }
 
     /**
@@ -134,5 +142,15 @@ class ExpressCheckoutController
         }
 
         return new IdentificationFormResponse($form);
+    }
+
+    /**
+     * @return string|null
+     */
+    private function resolveButtonStyle(): ?string
+    {
+        $settings = $this->expressCheckoutService->getExpressCheckoutSettings();
+
+        return $settings ? $settings->getButtonStyle() : null;
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/ExpressCheckoutAvailabilityResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/ExpressCheckoutAvailabilityResponse.php
@@ -25,7 +25,7 @@ class ExpressCheckoutAvailabilityResponse extends Response
      * @param bool $available
      * @param string|null $buttonStyle
      */
-    public function __construct(bool $available, ?string $buttonStyle)
+    public function __construct(bool $available, ?string $buttonStyle = null)
     {
         $this->available = $available;
         $this->buttonStyle = $buttonStyle;

--- a/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/ExpressCheckoutAvailabilityResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/ExpressCheckoutAvailabilityResponse.php
@@ -17,11 +17,18 @@ class ExpressCheckoutAvailabilityResponse extends Response
     protected $available;
 
     /**
-     * @param bool $available
+     * @var string|null
      */
-    public function __construct(bool $available)
+    protected $buttonStyle;
+
+    /**
+     * @param bool $available
+     * @param string|null $buttonStyle
+     */
+    public function __construct(bool $available, ?string $buttonStyle)
     {
         $this->available = $available;
+        $this->buttonStyle = $buttonStyle;
     }
 
     /**
@@ -29,6 +36,9 @@ class ExpressCheckoutAvailabilityResponse extends Response
      */
     public function toArray(): array
     {
-        return ['available' => $this->available];
+        return [
+            'available' => $this->available,
+            'buttonStyle' => $this->buttonStyle,
+        ];
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/GuestExpressCheckoutAvailabilityResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/GuestExpressCheckoutAvailabilityResponse.php
@@ -22,13 +22,20 @@ class GuestExpressCheckoutAvailabilityResponse extends Response
     protected $availableCountries;
 
     /**
+     * @var string|null
+     */
+    protected $buttonStyle;
+
+    /**
      * @param bool $available
      * @param string[] $availableCountries ISO country codes for which Express Checkout is available.
+     * @param string|null $buttonStyle
      */
-    public function __construct(bool $available, array $availableCountries)
+    public function __construct(bool $available, array $availableCountries, ?string $buttonStyle)
     {
         $this->available = $available;
         $this->availableCountries = $availableCountries;
+        $this->buttonStyle = $buttonStyle;
     }
 
     /**
@@ -39,6 +46,7 @@ class GuestExpressCheckoutAvailabilityResponse extends Response
         return [
             'available' => $this->available,
             'availableCountries' => $this->availableCountries,
+            'buttonStyle' => $this->buttonStyle,
         ];
     }
 }

--- a/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/GuestExpressCheckoutAvailabilityResponse.php
+++ b/src/BusinessLogic/CheckoutAPI/ExpressCheckout/Responses/GuestExpressCheckoutAvailabilityResponse.php
@@ -31,8 +31,11 @@ class GuestExpressCheckoutAvailabilityResponse extends Response
      * @param string[] $availableCountries ISO country codes for which Express Checkout is available.
      * @param string|null $buttonStyle
      */
-    public function __construct(bool $available, array $availableCountries, ?string $buttonStyle)
-    {
+    public function __construct(
+        bool $available,
+        array $availableCountries,
+        ?string $buttonStyle = null
+    ) {
         $this->available = $available;
         $this->availableCountries = $availableCountries;
         $this->buttonStyle = $buttonStyle;

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/ExpressCheckout/SaveExpressCheckoutSettingsHandler.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Handlers/ExpressCheckout/SaveExpressCheckoutSettingsHandler.php
@@ -7,6 +7,7 @@ use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Handlers\TopicHandlerInter
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\ExpressCheckout\SaveExpressCheckoutSettingsRequest;
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\ExpressCheckout\SaveExpressCheckoutSettingsResponse;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\DuplicatedExpressCheckoutPageException;
+use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutButtonStyleException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutPageConfigException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutPageException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Services\ExpressCheckoutService;
@@ -39,6 +40,7 @@ class SaveExpressCheckoutSettingsHandler implements TopicHandlerInterface
      * @throws InvalidExpressCheckoutPageException
      * @throws DuplicatedExpressCheckoutPageException
      * @throws InvalidExpressCheckoutPageConfigException
+     * @throws InvalidExpressCheckoutButtonStyleException
      */
     public function handle(array $payload): Response
     {

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
@@ -58,6 +58,10 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
 
         $buttonStyle = $payload['buttonStyle'] ?? null;
 
+        if ($buttonStyle === '') {
+            $buttonStyle = null;
+        }
+
         if ($buttonStyle !== null && !self::isWellFormedJson($buttonStyle)) {
             throw new InvalidExpressCheckoutButtonStyleException();
         }

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
@@ -4,6 +4,7 @@ namespace SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\ExpressChec
 
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Requests\ConfigurationWebhookRequest;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\DuplicatedExpressCheckoutPageException;
+use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutButtonStyleException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutPageConfigException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions\InvalidExpressCheckoutPageException;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Models\ExpressCheckoutPageConfig;
@@ -22,11 +23,18 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
     protected $expressCheckoutConfigs;
 
     /**
-     * @param ExpressCheckoutPageConfig[] $expressCheckoutConfigs
+     * @var string|null
      */
-    public function __construct(array $expressCheckoutConfigs)
+    protected $buttonStyle;
+
+    /**
+     * @param ExpressCheckoutPageConfig[] $expressCheckoutConfigs
+     * @param string|null $buttonStyle
+     */
+    public function __construct(array $expressCheckoutConfigs, ?string $buttonStyle = null)
     {
         $this->expressCheckoutConfigs = $expressCheckoutConfigs;
+        $this->buttonStyle = $buttonStyle;
     }
 
     /**
@@ -35,6 +43,7 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
      * @return self
      *
      * @throws InvalidExpressCheckoutPageException
+     * @throws InvalidExpressCheckoutButtonStyleException
      */
     public static function fromPayload(array $payload): object
     {
@@ -47,7 +56,13 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
             }
         }
 
-        return new self($configs);
+        $buttonStyle = $payload['buttonStyle'] ?? null;
+
+        if ($buttonStyle !== null && !self::isWellFormedJson($buttonStyle)) {
+            throw new InvalidExpressCheckoutButtonStyleException();
+        }
+
+        return new self($configs, $buttonStyle);
     }
 
     /**
@@ -58,6 +73,22 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
      */
     public function transformToDomainModel(): ExpressCheckoutSettings
     {
-        return new ExpressCheckoutSettings($this->expressCheckoutConfigs);
+        return new ExpressCheckoutSettings($this->expressCheckoutConfigs, $this->buttonStyle);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    private static function isWellFormedJson($value): bool
+    {
+        if (!\is_string($value)) {
+            return false;
+        }
+
+        json_decode($value);
+
+        return json_last_error() === JSON_ERROR_NONE;
     }
 }

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Requests/ExpressCheckout/SaveExpressCheckoutSettingsRequest.php
@@ -58,11 +58,7 @@ class SaveExpressCheckoutSettingsRequest extends ConfigurationWebhookRequest
 
         $buttonStyle = $payload['buttonStyle'] ?? null;
 
-        if ($buttonStyle === '') {
-            $buttonStyle = null;
-        }
-
-        if ($buttonStyle !== null && !self::isWellFormedJson($buttonStyle)) {
+        if ($buttonStyle !== null && $buttonStyle !== '' && !self::isWellFormedJson($buttonStyle)) {
             throw new InvalidExpressCheckoutButtonStyleException();
         }
 

--- a/src/BusinessLogic/ConfigurationWebhookAPI/Responses/ExpressCheckout/GetExpressCheckoutSettingsResponse.php
+++ b/src/BusinessLogic/ConfigurationWebhookAPI/Responses/ExpressCheckout/GetExpressCheckoutSettingsResponse.php
@@ -42,6 +42,9 @@ class GetExpressCheckoutSettingsResponse extends Response
         $configs = $this->expressCheckoutSettings
             ? $this->expressCheckoutSettings->getExpressCheckoutConfigs()
             : [];
+        $buttonStyle = $this->expressCheckoutSettings
+            ? $this->expressCheckoutSettings->getButtonStyle()
+            : null;
 
         return [
             'availablePages' => array_map(static function (ExpressCheckoutPage $page) {
@@ -50,6 +53,7 @@ class GetExpressCheckoutSettingsResponse extends Response
             'expressCheckoutConfigs' => array_map(static function (ExpressCheckoutPageConfig $config) {
                 return $config->toArray();
             }, $configs),
+            'buttonStyle' => $buttonStyle,
         ];
     }
 }

--- a/src/BusinessLogic/DataAccess/ExpressCheckout/Entities/ExpressCheckoutSettings.php
+++ b/src/BusinessLogic/DataAccess/ExpressCheckout/Entities/ExpressCheckoutSettings.php
@@ -68,12 +68,7 @@ class ExpressCheckoutSettings extends Entity
     {
         $data = parent::toArray();
         $data['storeId'] = $this->storeId;
-        $data['expressCheckoutSettings'] = [
-            'expressCheckoutConfigs' => array_map(static function (ExpressCheckoutPageConfig $config) {
-                return $config->toArray();
-            }, $this->expressCheckoutSettings->getExpressCheckoutConfigs()),
-            'buttonStyle' => $this->expressCheckoutSettings->getButtonStyle(),
-        ];
+        $data['expressCheckoutSettings'] = $this->expressCheckoutSettings->toArray();
 
         return $data;
     }

--- a/src/BusinessLogic/DataAccess/ExpressCheckout/Entities/ExpressCheckoutSettings.php
+++ b/src/BusinessLogic/DataAccess/ExpressCheckout/Entities/ExpressCheckoutSettings.php
@@ -53,7 +53,12 @@ class ExpressCheckoutSettings extends Entity
             }
         }
 
-        $this->expressCheckoutSettings = new DomainExpressCheckoutSettings($configs);
+        $buttonStyle = static::getDataValue($expressCheckoutSettings, 'buttonStyle', null);
+        if (!\is_string($buttonStyle)) {
+            $buttonStyle = null;
+        }
+
+        $this->expressCheckoutSettings = new DomainExpressCheckoutSettings($configs, $buttonStyle);
     }
 
     /**
@@ -67,6 +72,7 @@ class ExpressCheckoutSettings extends Entity
             'expressCheckoutConfigs' => array_map(static function (ExpressCheckoutPageConfig $config) {
                 return $config->toArray();
             }, $this->expressCheckoutSettings->getExpressCheckoutConfigs()),
+            'buttonStyle' => $this->expressCheckoutSettings->getButtonStyle(),
         ];
 
         return $data;

--- a/src/BusinessLogic/Domain/ExpressCheckout/Exceptions/InvalidExpressCheckoutButtonStyleException.php
+++ b/src/BusinessLogic/Domain/ExpressCheckout/Exceptions/InvalidExpressCheckoutButtonStyleException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions;
+
+use SeQura\Core\BusinessLogic\Domain\Translations\Model\BaseTranslatableException;
+use SeQura\Core\BusinessLogic\Domain\Translations\Model\TranslatableLabel;
+use Throwable;
+
+/**
+ * Class InvalidExpressCheckoutButtonStyleException.
+ *
+ * @package SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Exceptions
+ */
+class InvalidExpressCheckoutButtonStyleException extends BaseTranslatableException
+{
+    /**
+     * @var int
+     */
+    protected $code = 400;
+
+    /**
+     * @param ?Throwable $previous
+     */
+    public function __construct(?Throwable $previous = null)
+    {
+        parent::__construct(new TranslatableLabel(
+            'Invalid express checkout button style.',
+            'general.errors.expressCheckout.invalidButtonStyle'
+        ), $previous);
+    }
+}

--- a/src/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettings.php
+++ b/src/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettings.php
@@ -35,7 +35,7 @@ class ExpressCheckoutSettings
     {
         $this->validateConfigs($expressCheckoutConfigs);
         $this->expressCheckoutConfigs = array_values($expressCheckoutConfigs);
-        $this->buttonStyle = $buttonStyle;
+        $this->buttonStyle = $buttonStyle === '' ? null : $buttonStyle;
     }
 
     /**

--- a/src/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettings.php
+++ b/src/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettings.php
@@ -20,15 +20,22 @@ class ExpressCheckoutSettings
     protected $expressCheckoutConfigs;
 
     /**
+     * @var string|null
+     */
+    protected $buttonStyle;
+
+    /**
      * @param ExpressCheckoutPageConfig[] $expressCheckoutConfigs
+     * @param string|null $buttonStyle
      *
      * @throws InvalidExpressCheckoutPageConfigException When an entry is not an ExpressCheckoutPageConfig.
      * @throws DuplicatedExpressCheckoutPageException When two entries reference the same page.
      */
-    public function __construct(array $expressCheckoutConfigs = [])
+    public function __construct(array $expressCheckoutConfigs = [], ?string $buttonStyle = null)
     {
         $this->validateConfigs($expressCheckoutConfigs);
         $this->expressCheckoutConfigs = array_values($expressCheckoutConfigs);
+        $this->buttonStyle = $buttonStyle;
     }
 
     /**
@@ -37,6 +44,14 @@ class ExpressCheckoutSettings
     public function getExpressCheckoutConfigs(): array
     {
         return $this->expressCheckoutConfigs;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getButtonStyle(): ?string
+    {
+        return $this->buttonStyle;
     }
 
     /**
@@ -64,6 +79,7 @@ class ExpressCheckoutSettings
             'expressCheckoutConfigs' => array_map(static function (ExpressCheckoutPageConfig $config) {
                 return $config->toArray();
             }, $this->expressCheckoutConfigs),
+            'buttonStyle' => $this->buttonStyle,
         ];
     }
 

--- a/tests/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutControllerTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutControllerTest.php
@@ -114,18 +114,6 @@ class ExpressCheckoutControllerTest extends BaseTestCase
     /**
      * @return void
      */
-    public function testIsAvailableReturnsNullButtonStyleWhenNoSettingsStored(): void
-    {
-        $this->expressCheckoutService->setAvailability(true);
-
-        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
-
-        self::assertSame(['available' => true, 'buttonStyle' => null], $response->toArray());
-    }
-
-    /**
-     * @return void
-     */
     public function testIsAvailableOmitsStoredButtonStyleWhenUnavailable(): void
     {
         $buttonStyle = '{"color":"#00FF00","futureAttribute":"value"}';
@@ -223,24 +211,6 @@ class ExpressCheckoutControllerTest extends BaseTestCase
 
         self::assertSame(
             ['available' => true, 'availableCountries' => ['ES'], 'buttonStyle' => $buttonStyle],
-            $response->toArray()
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testIsAvailableForGuestReturnsNullButtonStyleWhenNoSettingsStored(): void
-    {
-        $this->expressCheckoutService->setGuestAvailability(true);
-        $this->countryConfigurationService->saveCountryConfiguration([
-            new CountryConfiguration('ES', 'merchant1'),
-        ]);
-
-        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
-
-        self::assertSame(
-            ['available' => true, 'availableCountries' => ['ES'], 'buttonStyle' => null],
             $response->toArray()
         );
     }

--- a/tests/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutControllerTest.php
+++ b/tests/BusinessLogic/CheckoutAPI/ExpressCheckout/Controller/ExpressCheckoutControllerTest.php
@@ -14,6 +14,7 @@ use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfigur
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\RepositoryContracts\CountryConfigurationRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\CountryConfigurationService;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\SellingCountriesService;
+use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Models\ExpressCheckoutSettings;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\Services\ExpressCheckoutService;
 use SeQura\Core\BusinessLogic\Domain\ExpressCheckout\RepositoryContracts\ExpressCheckoutSettingsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
@@ -81,7 +82,7 @@ class ExpressCheckoutControllerTest extends BaseTestCase
         $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
 
         self::assertTrue($response->isSuccessful());
-        self::assertSame(['available' => true], $response->toArray());
+        self::assertSame(['available' => true, 'buttonStyle' => null], $response->toArray());
     }
 
     /**
@@ -93,7 +94,47 @@ class ExpressCheckoutControllerTest extends BaseTestCase
 
         $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
 
-        self::assertSame(['available' => false], $response->toArray());
+        self::assertSame(['available' => false, 'buttonStyle' => null], $response->toArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableCarriesStoredButtonStyleVerbatim(): void
+    {
+        $buttonStyle = '{"color":"#00FF00","futureAttribute":"value"}';
+        $this->expressCheckoutService->setAvailability(true);
+        $this->expressCheckoutService->saveExpressCheckoutSettings(new ExpressCheckoutSettings([], $buttonStyle));
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
+
+        self::assertSame(['available' => true, 'buttonStyle' => $buttonStyle], $response->toArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableReturnsNullButtonStyleWhenNoSettingsStored(): void
+    {
+        $this->expressCheckoutService->setAvailability(true);
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
+
+        self::assertSame(['available' => true, 'buttonStyle' => null], $response->toArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableOmitsStoredButtonStyleWhenUnavailable(): void
+    {
+        $buttonStyle = '{"color":"#00FF00","futureAttribute":"value"}';
+        $this->expressCheckoutService->setAvailability(false);
+        $this->expressCheckoutService->saveExpressCheckoutSettings(new ExpressCheckoutSettings([], $buttonStyle));
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailable($this->buildRequest());
+
+        self::assertSame(['available' => false, 'buttonStyle' => null], $response->toArray());
     }
 
     /**
@@ -110,7 +151,10 @@ class ExpressCheckoutControllerTest extends BaseTestCase
         $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
 
         self::assertTrue($response->isSuccessful());
-        self::assertSame(['available' => true, 'availableCountries' => ['ES', 'FR']], $response->toArray());
+        self::assertSame(
+            ['available' => true, 'availableCountries' => ['ES', 'FR'], 'buttonStyle' => null],
+            $response->toArray()
+        );
     }
 
     /**
@@ -125,7 +169,10 @@ class ExpressCheckoutControllerTest extends BaseTestCase
 
         $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
 
-        self::assertSame(['available' => false, 'availableCountries' => []], $response->toArray());
+        self::assertSame(
+            ['available' => false, 'availableCountries' => [], 'buttonStyle' => null],
+            $response->toArray()
+        );
     }
 
     /**
@@ -137,7 +184,65 @@ class ExpressCheckoutControllerTest extends BaseTestCase
 
         $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
 
-        self::assertSame(['available' => false, 'availableCountries' => []], $response->toArray());
+        self::assertSame(
+            ['available' => false, 'availableCountries' => [], 'buttonStyle' => null],
+            $response->toArray()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableForGuestOmitsStoredButtonStyleWhenNoCountriesConfigured(): void
+    {
+        $buttonStyle = '{"color":"#00FF00","futureAttribute":"value"}';
+        $this->expressCheckoutService->setGuestAvailability(true);
+        $this->expressCheckoutService->saveExpressCheckoutSettings(new ExpressCheckoutSettings([], $buttonStyle));
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
+
+        self::assertSame(
+            ['available' => false, 'availableCountries' => [], 'buttonStyle' => null],
+            $response->toArray()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableForGuestCarriesStoredButtonStyleVerbatim(): void
+    {
+        $buttonStyle = '{"color":"#00FF00","futureAttribute":"value"}';
+        $this->expressCheckoutService->setGuestAvailability(true);
+        $this->expressCheckoutService->saveExpressCheckoutSettings(new ExpressCheckoutSettings([], $buttonStyle));
+        $this->countryConfigurationService->saveCountryConfiguration([
+            new CountryConfiguration('ES', 'merchant1'),
+        ]);
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
+
+        self::assertSame(
+            ['available' => true, 'availableCountries' => ['ES'], 'buttonStyle' => $buttonStyle],
+            $response->toArray()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAvailableForGuestReturnsNullButtonStyleWhenNoSettingsStored(): void
+    {
+        $this->expressCheckoutService->setGuestAvailability(true);
+        $this->countryConfigurationService->saveCountryConfiguration([
+            new CountryConfiguration('ES', 'merchant1'),
+        ]);
+
+        $response = CheckoutAPI::get()->expressCheckout('1')->isAvailableForGuest($this->buildGuestRequest());
+
+        self::assertSame(
+            ['available' => true, 'availableCountries' => ['ES'], 'buttonStyle' => null],
+            $response->toArray()
+        );
     }
 
     /**

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -2232,6 +2232,7 @@ class ConfigurationWebhookAPITest extends BaseTestCase
         self::assertEquals([
             'availablePages' => ['product', 'cart', 'mini-cart'],
             'expressCheckoutConfigs' => [],
+            'buttonStyle' => null,
         ], $response->toArray());
     }
 
@@ -2268,6 +2269,7 @@ class ConfigurationWebhookAPITest extends BaseTestCase
                 ['page' => 'cart', 'enabled' => false],
                 ['page' => 'mini-cart', 'enabled' => true],
             ],
+            'buttonStyle' => null,
         ], $response->toArray());
     }
 
@@ -2298,6 +2300,7 @@ class ConfigurationWebhookAPITest extends BaseTestCase
         self::assertCount(2, $persisted->getExpressCheckoutConfigs());
         self::assertTrue($persisted->isPageEnabled(ExpressCheckoutPage::product()->getPage()));
         self::assertFalse($persisted->isPageEnabled(ExpressCheckoutPage::cart()->getPage()));
+        self::assertNull($persisted->getButtonStyle());
     }
 
     /**
@@ -2334,5 +2337,130 @@ class ConfigurationWebhookAPITest extends BaseTestCase
         self::assertFalse($persisted->isPageEnabled(ExpressCheckoutPage::product()->getPage()));
         self::assertFalse($persisted->isPageEnabled(ExpressCheckoutPage::cart()->getPage()));
         self::assertTrue($persisted->isPageEnabled(ExpressCheckoutPage::miniCart()->getPage()));
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testSaveExpressCheckoutSettingsStoresUnknownButtonStyleAttributesVerbatim(): void
+    {
+        //Arrange
+        $buttonStyle = '{"attributeThisReleaseNeverHeardOf":"<script>x</script>",'
+            . '"weird key":[1,2,{"deep":null}],"__proto__":"  spaced  "}';
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-express-checkout-settings",
+                "expressCheckoutConfigs" => [
+                    ['page' => 'product', 'enabled' => true],
+                ],
+                "buttonStyle" => $buttonStyle,
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        $persisted = $this->expressCheckoutSettingsService->getExpressCheckoutSettings();
+        self::assertNotNull($persisted);
+        self::assertSame($buttonStyle, $persisted->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testSaveExpressCheckoutSettingsRejectsMalformedButtonStyle(): void
+    {
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-express-checkout-settings",
+                "expressCheckoutConfigs" => [
+                    ['page' => 'product', 'enabled' => true],
+                ],
+                "buttonStyle" => '{"backgroundColor":',
+            ]
+        );
+
+        //Assert
+        self::assertFalse($response->isSuccessful());
+        self::assertEquals([
+            'statusCode' => 400,
+            'errorCode' => 'general.errors.expressCheckout.invalidButtonStyle',
+            'errorMessage' => 'Invalid express checkout button style.',
+            'errorParameters' => [],
+        ], $response->toArray());
+        self::assertNull($this->expressCheckoutSettingsService->getExpressCheckoutSettings());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testSaveExpressCheckoutSettingsRejectsNonStringButtonStyle(): void
+    {
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-express-checkout-settings",
+                "expressCheckoutConfigs" => [],
+                "buttonStyle" => ['backgroundColor' => '#000000'],
+            ]
+        );
+
+        //Assert
+        self::assertFalse($response->isSuccessful());
+        self::assertEquals(
+            'general.errors.expressCheckout.invalidButtonStyle',
+            $response->toArray()['errorCode']
+        );
+        self::assertNull($this->expressCheckoutSettingsService->getExpressCheckoutSettings());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testExpressCheckoutButtonStyleRoundTripsThroughGetResponse(): void
+    {
+        //Arrange
+        $buttonStyle = '{"unknownFutureProp":"x","nested":{"a":[1,2]}}';
+        ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-express-checkout-settings",
+                "expressCheckoutConfigs" => [
+                    ['page' => 'product', 'enabled' => true],
+                ],
+                "buttonStyle" => $buttonStyle,
+            ]
+        );
+
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "get-express-checkout-settings"
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        self::assertEquals([
+            'availablePages' => ['product', 'cart', 'mini-cart'],
+            'expressCheckoutConfigs' => [
+                ['page' => 'product', 'enabled' => true],
+            ],
+            'buttonStyle' => $buttonStyle,
+        ], $response->toArray());
     }
 }

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -2374,11 +2374,6 @@ class ConfigurationWebhookAPITest extends BaseTestCase
      *
      * @throws InvalidEnvironmentException
      */
-    /**
-     * @return void
-     *
-     * @throws InvalidEnvironmentException
-     */
     public function testSaveExpressCheckoutSettingsTreatsAnEmptyButtonStyleAsUnset(): void
     {
         //Act

--- a/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
+++ b/tests/BusinessLogic/ConfigurationWebhookAPI/ConfigurationWebhookAPITest.php
@@ -2374,6 +2374,37 @@ class ConfigurationWebhookAPITest extends BaseTestCase
      *
      * @throws InvalidEnvironmentException
      */
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    public function testSaveExpressCheckoutSettingsTreatsAnEmptyButtonStyleAsUnset(): void
+    {
+        //Act
+        $response = ConfigurationWebhookAPI::configurationHandler()->handleRequest(
+            $this->signature,
+            [
+                "topic" => "save-express-checkout-settings",
+                "expressCheckoutConfigs" => [
+                    ['page' => 'product', 'enabled' => true],
+                ],
+                "buttonStyle" => '',
+            ]
+        );
+
+        //Assert
+        self::assertTrue($response->isSuccessful());
+        $persisted = $this->expressCheckoutSettingsService->getExpressCheckoutSettings();
+        self::assertNotNull($persisted);
+        self::assertNull($persisted->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
     public function testSaveExpressCheckoutSettingsRejectsMalformedButtonStyle(): void
     {
         //Act

--- a/tests/BusinessLogic/DataAccess/ExpressCheckout/Repositories/ExpressCheckoutSettingsRepositoryTest.php
+++ b/tests/BusinessLogic/DataAccess/ExpressCheckout/Repositories/ExpressCheckoutSettingsRepositoryTest.php
@@ -173,6 +173,80 @@ class ExpressCheckoutSettingsRepositoryTest extends BaseTestCase
     }
 
     /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testGetExpressCheckoutSettingsToleratesLegacyRowWithoutButtonStyle(): void
+    {
+        // Arrange
+        $entity = new ExpressCheckoutSettingsEntity();
+        $entity->inflate([
+            'storeId' => '1',
+            'expressCheckoutSettings' => [
+                'expressCheckoutConfigs' => [],
+            ],
+        ]);
+        TestRepositoryRegistry::getRepository(ExpressCheckoutSettingsEntity::getClassName())->save($entity);
+
+        // Act
+        $loaded = StoreContext::doWithStore('1', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertNotNull($loaded);
+        self::assertNull($loaded->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testSetExpressCheckoutSettingsRoundTripsOpaqueButtonStyle(): void
+    {
+        // Arrange
+        $buttonStyle = '{"backgroundColor":"#123456","somethingNewerThanThisRelease":true}';
+        $settings = new ExpressCheckoutSettings(
+            [new ExpressCheckoutPageConfig(ExpressCheckoutPage::product(), true)],
+            $buttonStyle
+        );
+
+        // Act
+        StoreContext::doWithStore('1', [$this->repository, 'setExpressCheckoutSettings'], [$settings]);
+        $loaded = StoreContext::doWithStore('1', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertNotNull($loaded);
+        self::assertSame($buttonStyle, $loaded->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testGetExpressCheckoutSettingsDegradesNonStringButtonStyleToNull(): void
+    {
+        // Arrange
+        $entity = new ExpressCheckoutSettingsEntity();
+        $entity->inflate([
+            'storeId' => '1',
+            'expressCheckoutSettings' => [
+                'expressCheckoutConfigs' => [],
+                'buttonStyle' => ['backgroundColor' => '#123456'],
+            ],
+        ]);
+        TestRepositoryRegistry::getRepository(ExpressCheckoutSettingsEntity::getClassName())->save($entity);
+
+        // Act
+        $loaded = StoreContext::doWithStore('1', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertNotNull($loaded);
+        self::assertNull($loaded->getButtonStyle());
+    }
+
+    /**
      * @param string $storeId
      *
      * @return ExpressCheckoutSettingsEntity[]

--- a/tests/BusinessLogic/DataAccess/ExpressCheckout/Repositories/ExpressCheckoutSettingsRepositoryTest.php
+++ b/tests/BusinessLogic/DataAccess/ExpressCheckout/Repositories/ExpressCheckoutSettingsRepositoryTest.php
@@ -225,6 +225,57 @@ class ExpressCheckoutSettingsRepositoryTest extends BaseTestCase
      *
      * @throws Exception
      */
+    public function testSetExpressCheckoutSettingsScopesButtonStyleByStore(): void
+    {
+        // Arrange
+        $buttonStyleOne = '{"backgroundColor":"#123456"}';
+        $buttonStyleTwo = '{"backgroundColor":"#abcdef"}';
+        $storeOne = new ExpressCheckoutSettings(
+            [new ExpressCheckoutPageConfig(ExpressCheckoutPage::product(), true)],
+            $buttonStyleOne
+        );
+        $storeTwo = new ExpressCheckoutSettings(
+            [new ExpressCheckoutPageConfig(ExpressCheckoutPage::cart(), true)],
+            $buttonStyleTwo
+        );
+
+        // Act
+        StoreContext::doWithStore('1', [$this->repository, 'setExpressCheckoutSettings'], [$storeOne]);
+        StoreContext::doWithStore('2', [$this->repository, 'setExpressCheckoutSettings'], [$storeTwo]);
+        $loadedOne = StoreContext::doWithStore('1', [$this->repository, 'getExpressCheckoutSettings']);
+        $loadedTwo = StoreContext::doWithStore('2', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertSame($buttonStyleOne, $loadedOne->getButtonStyle());
+        self::assertSame($buttonStyleTwo, $loadedTwo->getButtonStyle());
+
+        // Act - updating store '1' must leave store '2' untouched
+        $buttonStyleOneUpdated = '{"backgroundColor":"#000000"}';
+        $storeOneUpdated = new ExpressCheckoutSettings(
+            [new ExpressCheckoutPageConfig(ExpressCheckoutPage::product(), true)],
+            $buttonStyleOneUpdated
+        );
+        StoreContext::doWithStore('1', [$this->repository, 'setExpressCheckoutSettings'], [$storeOneUpdated]);
+        $loadedOneAfterUpdate = StoreContext::doWithStore('1', [$this->repository, 'getExpressCheckoutSettings']);
+        $loadedTwoAfterUpdate = StoreContext::doWithStore('2', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertSame($buttonStyleOneUpdated, $loadedOneAfterUpdate->getButtonStyle());
+        self::assertSame($buttonStyleTwo, $loadedTwoAfterUpdate->getButtonStyle());
+
+        // Act - a store with no settings at all
+        $loadedThree = StoreContext::doWithStore('3', [$this->repository, 'getExpressCheckoutSettings']);
+
+        // Assert
+        self::assertNull($loadedThree);
+        self::assertSame($buttonStyleTwo, $loadedTwoAfterUpdate->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
     public function testGetExpressCheckoutSettingsDegradesNonStringButtonStyleToNull(): void
     {
         // Arrange

--- a/tests/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettingsTest.php
+++ b/tests/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettingsTest.php
@@ -168,6 +168,7 @@ class ExpressCheckoutSettingsTest extends TestCase
                 ['page' => 'cart', 'enabled' => false],
                 ['page' => 'mini-cart', 'enabled' => true],
             ],
+            'buttonStyle' => null,
         ], $settings->toArray());
     }
 
@@ -178,6 +179,35 @@ class ExpressCheckoutSettingsTest extends TestCase
     {
         $settings = new ExpressCheckoutSettings();
 
-        self::assertSame(['expressCheckoutConfigs' => []], $settings->toArray());
+        self::assertSame(['expressCheckoutConfigs' => [], 'buttonStyle' => null], $settings->toArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testButtonStyleDefaultsToNull(): void
+    {
+        $settings = new ExpressCheckoutSettings();
+
+        self::assertNull($settings->getButtonStyle());
+    }
+
+    /**
+     * @return void
+     *
+     * @throws DuplicatedExpressCheckoutPageException
+     * @throws InvalidExpressCheckoutPageConfigException
+     */
+    public function testButtonStyleIsCarriedVerbatim(): void
+    {
+        $buttonStyle = '{"backgroundColor":"#123456","somethingNewerThanThisRelease":true}';
+
+        $settings = new ExpressCheckoutSettings(
+            [new ExpressCheckoutPageConfig(ExpressCheckoutPage::product(), true)],
+            $buttonStyle
+        );
+
+        self::assertSame($buttonStyle, $settings->getButtonStyle());
+        self::assertSame($buttonStyle, $settings->toArray()['buttonStyle']);
     }
 }

--- a/tests/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettingsTest.php
+++ b/tests/BusinessLogic/Domain/ExpressCheckout/Models/ExpressCheckoutSettingsTest.php
@@ -194,6 +194,16 @@ class ExpressCheckoutSettingsTest extends TestCase
 
     /**
      * @return void
+     */
+    public function testConstructorTreatsAnEmptyButtonStyleAsUnset(): void
+    {
+        $settings = new ExpressCheckoutSettings([], '');
+
+        self::assertNull($settings->getButtonStyle());
+    }
+
+    /**
+     * @return void
      *
      * @throws DuplicatedExpressCheckoutPageException
      * @throws InvalidExpressCheckoutPageConfigException


### PR DESCRIPTION
### What is the goal?

Merchants can now style the express checkout button from the Merchant Portal — colours, corner radius, font size and uppercase text. This package carries that configuration from the portal out to the storefront.

### References

* **Issue:** https://sequra.atlassian.net/browse/PAR-848
* **Related pull-requests:** sequra/merchant-portal-frontend#1731, sequra/integration-assets#669, sequra/magento2-core#122

### How is it being implemented?

- A `buttonStyle` string is threaded through the settings model, the stored entity, the configuration webhook and both availability responses.
- **This package never looks inside it.** It checks the string parses as JSON and nothing else, so adding a style property later touches only the portal and the CDN asset — not this package, not any deployed plugin. The rendered button holds the allow-list and does all sanitising.
- No migration: the entity already stores a serialised blob, and settings written before this change load as unset without throwing.
- The value rides the availability response rather than the integration interface, which would fatal every deployed plugin if extended.

### Caveats

Nothing bounds the blob's length here. The CDN library caps what it forwards, so an oversized value degrades rather than breaking.

### Does it affect (changes or update) any sensitive data?

No. Presentation values a merchant picks for their own storefront button.

### How is it tested?

Automated tests, including that an attribute this release does not know survives the round trip untouched, and that one store's style never reaches another.

### How is it going to be deployed?

Standard deployment.
